### PR TITLE
[Feat] #12 - Networking 모듈에 RequestBody, QueryItem 타입으로 변환이 용이하도록 편의 프로토콜 추가

### DIFF
--- a/Projects/Core/Networking/Sources/QueryItemConvertible.swift
+++ b/Projects/Core/Networking/Sources/QueryItemConvertible.swift
@@ -13,7 +13,7 @@ protocol QueryItemConvertible: Encodable {
 }
 
 extension QueryItemConvertible {
-    var asQueryItems: [URLQueryItem] {
+    func asQueryItems() -> [URLQueryItem] {
         // Encodable -> Data -> [String: Any]
         guard let data = try? JSONEncoder().encode(self),
               let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/Projects/Core/Networking/Sources/QueryItemConvertible.swift
+++ b/Projects/Core/Networking/Sources/QueryItemConvertible.swift
@@ -1,0 +1,53 @@
+//
+//  QueryItemConvertible.swift
+//  Networking
+//
+//  Created by YunhakLee on 11/24/25.
+//  Copyright © 2025 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+protocol QueryItemConvertible: Encodable {
+    var asQueryItems: [URLQueryItem] { get }
+}
+
+extension QueryItemConvertible {
+    var asQueryItems: [URLQueryItem] {
+        // Encodable -> Data -> [String: Any]
+        guard let data = try? JSONEncoder().encode(self),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return []
+        }
+
+        return jsonObject.compactMap { key, value in
+            // 1) Optional nil(jsonObject에서는 NSNull)인 값은 쿼리에서 제외
+            if value is NSNull {
+                return nil
+            }
+
+            // 2) Bool은 항상 "true"/"false"로
+            if let bool = value as? Bool {
+                return URLQueryItem(name: key, value: bool ? "true" : "false")
+            }
+
+            // 3) 배열인 경우: 요소별로 다시 한 번 타입 체크 후 ","로 join
+            if let array = value as? [Any] {
+                let joined = array.compactMap { element -> String? in
+                    // 배열 안의 null도 제거
+                    if element is NSNull { return nil }
+
+                    if let boolElement = element as? Bool {
+                        return boolElement ? "true" : "false"
+                    }
+
+                    return String(describing: element)
+                }.joined(separator: ",")
+                return URLQueryItem(name: key, value: joined)
+            }
+
+            // 4) 나머지 단일 값(Int, String 등)은 문자열로 변환
+            return URLQueryItem(name: key, value: String(describing: value))
+        }
+    }
+}

--- a/Projects/Core/Networking/Sources/RequestBodyConvertible.swift
+++ b/Projects/Core/Networking/Sources/RequestBodyConvertible.swift
@@ -14,7 +14,6 @@ protocol RequestBodyConvertible: Encodable {
 
 extension RequestBodyConvertible {
     func asRequestBody() -> Data? {
-        // 나중에 여기서 공통 encoder, date 전략, key 전략 등도 통일 가능
         try? JSONEncoder().encode(self)
     }
     

--- a/Projects/Core/Networking/Sources/RequestBodyConvertible.swift
+++ b/Projects/Core/Networking/Sources/RequestBodyConvertible.swift
@@ -1,0 +1,21 @@
+//
+//  RequestBodyConvertible.swift
+//  Networking
+//
+//  Created by YunhakLee on 11/24/25.
+//  Copyright © 2025 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+protocol RequestBodyConvertible: Encodable {
+    func asRequestBody() -> Data?
+}
+
+extension RequestBodyConvertible {
+    func asRequestBody() -> Data? {
+        // 나중에 여기서 공통 encoder, date 전략, key 전략 등도 통일 가능
+        try? JSONEncoder().encode(self)
+    }
+    
+}


### PR DESCRIPTION
## 💡 Issue
<!-- closed #1 -->
#12 
<br>

## 💭 Summary
<!-- 작업에 대한 간단한 소개 -->
- Networking 모듈에 RequestBody, QueryItem 타입으로 변환이 용이하도록 편의 프로토콜을 추가 하였음
<br>

## 🔑 Key Changes
<!-- 작업에 대한 구체적인 설명 -->
- Endpoint를 Data layer에서 작성할 때, Endpoint에서 요구하는 값에 맞추기 위해 Endpoint 내부에서 Body를 Encoding하거나 QueryItem으로 변환하는 작업이 필요했음.
- 즉, Endpoint가 데이터 변환 책임을 갖는 형태로 작성되었는데, 이 책임을 각각의 프로토콜에 옮김으로써 Endpoint 작성시 구체적인 데이터 변환 과정을 모르도록 변경함.

적용 전.
```swift
// NotificationEndpoint.swift

  var queryItems: [URLQueryItem]? {
        switch self {
        case .getNotifications(let query):
            let notificationsQueryItems: [URLQueryItem] = [
                URLQueryItem(name: "lastNotificationId", value: String(describing: query.lastNotificationId)),
                URLQueryItem(name: "size", value: String(describing: query.size))
            ]
            return notificationsQueryItems
        default: return nil
        }
    }
```

적용 후
```swift
// NotificationEndpoint.swift

  var queryItems: [URLQueryItem]? {
        switch self {
        case .getNotifications(let query): return query.asQueryItems()
        default: return nil
        }
    }

```
<br>

## 📱 Simulation
<!-- 작업에 대한 UI 시뮬레이터 -->

<br>

## 🧑‍🧒‍🧒 To Reviewer
<!-- 리뷰어에게 전달할 내용 -->

<br>

## ※ Reference
<!-- 작업 시 참고한 레퍼런스 -->
