### PR TITLE
[Feat] #34 - Recommendation Domain 모듈 구현

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Target.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+Target.swift
@@ -58,6 +58,11 @@ public extension TargetDependency.Domain {
         path: .relativeToDomain(.recommendation)
     )
     
+    static let RecommendationDomainTesting = TargetDependency.project(
+        target: ModuleType.Domain.recommendation.targetName(type: .testing),
+        path: .relativeToDomain(.recommendation)
+    )
+    
     static let FeedDomain = TargetDependency.project(
         target: ModuleType.Domain.feed.targetName(type: .sources),
         path: .relativeToDomain(.feed)

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/TargetType.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/TargetType.swift
@@ -19,6 +19,7 @@ public enum TargetType {
         case .demo: return "Demo"
         case .testing: return "Testing"
         case .tests: return "Tests"
+        case .testing: return "Testing"
         }
     }
 }

--- a/Projects/Domain/Recommendation/Demo/ContentView.swift
+++ b/Projects/Domain/Recommendation/Demo/ContentView.swift
@@ -1,0 +1,19 @@
+//
+//  ContentView.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Projects/Domain/Recommendation/Demo/RecommendationDomainDemoApp.swift
+++ b/Projects/Domain/Recommendation/Demo/RecommendationDomainDemoApp.swift
@@ -1,0 +1,18 @@
+//
+//  RecommendationDomainDemoApp.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import SwiftUI
+
+@main
+struct RecommendationDomainDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Projects/Domain/Recommendation/Project.swift
+++ b/Projects/Domain/Recommendation/Project.swift
@@ -1,0 +1,16 @@
+//
+//  Project.swift
+//  AppManifests
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.createDomainModule(
+    name: ModuleType.Domain.recommendation.name,
+    targets: [.sources, .demo, .tests, .testing],
+    internalDependencies: [.Domain.BaseDomain]
+)

--- a/Projects/Domain/Recommendation/Sources/Entity/InterestFeed/InterestFeed.swift
+++ b/Projects/Domain/Recommendation/Sources/Entity/InterestFeed/InterestFeed.swift
@@ -1,0 +1,25 @@
+//
+//  InterestFeed.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+/// 홈 - 관심글
+
+public struct InterestFeed {
+    
+    public let novelID: NovelID
+    
+    public let novelTitle: String
+    public let novelThumbnailImage: URL?
+    public let novelRating: Float
+    public let novelRatingCount: Int
+    
+    public let user: Author
+    public let userComment: String
+}

--- a/Projects/Domain/Recommendation/Sources/Entity/InterestFeed/InterestFeedState.swift
+++ b/Projects/Domain/Recommendation/Sources/Entity/InterestFeed/InterestFeedState.swift
@@ -1,0 +1,17 @@
+//
+//  InterestFeedState.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+/// 홈 - 관심글 상태
+
+public enum InterestFeedState {
+    case feeds([InterestFeed])
+    case noInterestSettings   // 관심 설정 안 함
+    case noAssociatedFeeds    // 관련 피드 없음
+}

--- a/Projects/Domain/Recommendation/Sources/Entity/RecommendedNovel/RecommendedNovel.swift
+++ b/Projects/Domain/Recommendation/Sources/Entity/RecommendedNovel/RecommendedNovel.swift
@@ -1,0 +1,24 @@
+//
+//  RecommendedNovel.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+/// 홈 - 선호 장르 기반 작품
+
+public struct RecommendedNovel {
+    
+    public let novelID: NovelID
+    
+    public let novelTitle: String
+    public let novelThumbnailImage: URL?
+    public let novelAuthors: [String]
+    
+    public let interestCount: Int
+    public let ratingCount: Int
+}

--- a/Projects/Domain/Recommendation/Sources/Entity/RecommendedNovel/RecommendedNovelState.swift
+++ b/Projects/Domain/Recommendation/Sources/Entity/RecommendedNovel/RecommendedNovelState.swift
@@ -1,0 +1,16 @@
+//
+//  RecommendedNovelState.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+/// 홈 - 선호 장르 기반 작품 상태
+
+public enum RecommendedNovelState {
+    case novels([RecommendedNovel])   // 데이터 있음
+    case noGenreSettings              // 선호 장르 미설정
+}

--- a/Projects/Domain/Recommendation/Sources/Entity/SosoPick.swift
+++ b/Projects/Domain/Recommendation/Sources/Entity/SosoPick.swift
@@ -1,0 +1,18 @@
+//
+//  SosoPick.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+public struct SosoPick {
+    
+    public let novelID: NovelID
+    
+    public let novelTitle: String
+    public let novelThumbnailimage: URL?
+}

--- a/Projects/Domain/Recommendation/Sources/Entity/TodayDiscovery.swift
+++ b/Projects/Domain/Recommendation/Sources/Entity/TodayDiscovery.swift
@@ -1,0 +1,29 @@
+//
+//  TodayDiscovery.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+/// 홈 - 오늘의 발견
+
+public struct TodayDiscovery {
+
+    public let novelID: NovelID
+    
+    public let novelTitle: String
+    public let novelThumbnailImage: URL?
+    public let content: Content
+    
+    // 타입에 따른 Content 분기 처리
+    // novel: 작품 설명
+    // userComment: 유저의 작품에 대한 한마디
+    public enum Content {
+        case novel(description: String)
+        case userComment(user: Author, comment: String)
+    }
+}

--- a/Projects/Domain/Recommendation/Sources/Entity/TrendingFeed.swift
+++ b/Projects/Domain/Recommendation/Sources/Entity/TrendingFeed.swift
@@ -1,0 +1,20 @@
+//
+//  TrendingFeed.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+/// 홈 - 지금 뜨는 글 
+
+public struct TrendingFeed {
+    public let feedID: FeedID
+    
+    public let description: String
+    public let likeCount: Int
+    public let commentCount: Int
+}

--- a/Projects/Domain/Recommendation/Sources/Repository/RecommendationRepository.swift
+++ b/Projects/Domain/Recommendation/Sources/Repository/RecommendationRepository.swift
@@ -1,0 +1,17 @@
+//
+//  RecommendationRepository.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol RecommendationRepository {
+    func fetchTodayDiscoveries() async throws -> [TodayDiscovery]
+    func fetchTrendingFeeds() async throws -> [TrendingFeed]
+    func fetchInterestFeeds() async throws -> InterestFeedState
+    func fetchRecommendedNovels() async throws -> RecommendedNovelState
+    func fetchSosoPick() async throws -> [SosoPick]
+}

--- a/Projects/Domain/Recommendation/Sources/Usecase/HomeData.swift
+++ b/Projects/Domain/Recommendation/Sources/Usecase/HomeData.swift
@@ -1,0 +1,16 @@
+//
+//  HomeData.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct HomeData {
+    public let todayDiscoveries: Result<[TodayDiscovery], Error>
+    public let trendingFeeds: Result<[TrendingFeed], Error>
+    public let interestFeedState: Result<InterestFeedState, Error>
+    public let recommendedNovelState: Result<RecommendedNovelState, Error>
+}

--- a/Projects/Domain/Recommendation/Sources/Usecase/HomeData.swift
+++ b/Projects/Domain/Recommendation/Sources/Usecase/HomeData.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct HomeData {
-    public let todayDiscoveries: Result<[TodayDiscovery], Error>
-    public let trendingFeeds: Result<[TrendingFeed], Error>
-    public let interestFeedState: Result<InterestFeedState, Error>
-    public let recommendedNovelState: Result<RecommendedNovelState, Error>
+    public let todayDiscoveries: [TodayDiscovery]
+    public let trendingFeeds: [TrendingFeed]
+    public let interestFeedState: InterestFeedState
+    public let recommendedNovelState: RecommendedNovelState
 }

--- a/Projects/Domain/Recommendation/Sources/Usecase/LoadHomeDataUsecase.swift
+++ b/Projects/Domain/Recommendation/Sources/Usecase/LoadHomeDataUsecase.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol LoadHomeDataUsecase {
-    func execute() async -> HomeData
+    func execute() async throws -> HomeData
 }
 
 public final class DefaultLoadDataUsecase: LoadHomeDataUsecase {
@@ -20,29 +20,17 @@ public final class DefaultLoadDataUsecase: LoadHomeDataUsecase {
         self.recommendationRepository = repository
     }
     
-    public func execute() async -> HomeData {
-        async let todayDiscoveries: Result<[TodayDiscovery], Error> = {
-            do { return .success(try await recommendationRepository.fetchTodayDiscoveries()) }
-            catch { return .failure(error) }
-        }()
-        async let trendingFeeds: Result<[TrendingFeed], Error> = {
-            do { return .success(try await recommendationRepository.fetchTrendingFeeds()) }
-            catch { return .failure(error) }
-        }()
-        async let interestFeeds: Result<InterestFeedState, Error> = {
-            do { return .success(try await recommendationRepository.fetchInterestFeeds()) }
-            catch { return .failure(error) }
-        }()
-        async let recommendedNovels: Result<RecommendedNovelState, Error> = {
-            do { return .success(try await recommendationRepository.fetchRecommendedNovels()) }
-            catch { return .failure(error) }
-        }()
+    public func execute() async throws -> HomeData {
+        async let todayDiscoveries = recommendationRepository.fetchTodayDiscoveries()
+        async let trendingFeeds = recommendationRepository.fetchTrendingFeeds()
+        async let interestFeedState = recommendationRepository.fetchInterestFeeds()
+        async let recommendedNovelState = recommendationRepository.fetchRecommendedNovels()
         
         return await HomeData(
-            todayDiscoveries: todayDiscoveries,
-            trendingFeeds: trendingFeeds,
-            interestFeedState: interestFeeds,
-            recommendedNovelState: recommendedNovels
+            todayDiscoveries: try todayDiscoveries,
+            trendingFeeds: try trendingFeeds,
+            interestFeedState: try interestFeedState,
+            recommendedNovelState: try recommendedNovelState
         )
     }
 }

--- a/Projects/Domain/Recommendation/Sources/Usecase/LoadHomeDataUsecase.swift
+++ b/Projects/Domain/Recommendation/Sources/Usecase/LoadHomeDataUsecase.swift
@@ -1,0 +1,48 @@
+//
+//  LoadHomeDataUsecase.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoadHomeDataUsecase {
+    func execute() async -> HomeData
+}
+
+public final class DefaultLoadDataUsecase: LoadHomeDataUsecase {
+    
+    private let recommendationRepository: RecommendationRepository
+    
+    public init(repository: RecommendationRepository) {
+        self.recommendationRepository = repository
+    }
+    
+    public func execute() async -> HomeData {
+        async let todayDiscoveries: Result<[TodayDiscovery], Error> = {
+            do { return .success(try await recommendationRepository.fetchTodayDiscoveries()) }
+            catch { return .failure(error) }
+        }()
+        async let trendingFeeds: Result<[TrendingFeed], Error> = {
+            do { return .success(try await recommendationRepository.fetchTrendingFeeds()) }
+            catch { return .failure(error) }
+        }()
+        async let interestFeeds: Result<InterestFeedState, Error> = {
+            do { return .success(try await recommendationRepository.fetchInterestFeeds()) }
+            catch { return .failure(error) }
+        }()
+        async let recommendedNovels: Result<RecommendedNovelState, Error> = {
+            do { return .success(try await recommendationRepository.fetchRecommendedNovels()) }
+            catch { return .failure(error) }
+        }()
+        
+        return await HomeData(
+            todayDiscoveries: todayDiscoveries,
+            trendingFeeds: trendingFeeds,
+            interestFeedState: interestFeeds,
+            recommendedNovelState: recommendedNovels
+        )
+    }
+}

--- a/Projects/Domain/Recommendation/Sources/Usecase/LoadSosoPickUsecase.swift
+++ b/Projects/Domain/Recommendation/Sources/Usecase/LoadSosoPickUsecase.swift
@@ -1,0 +1,26 @@
+//
+//  LoadSosoPickUsecase.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoadSosoPickUsecase {
+    func execute() async throws -> [SosoPick]
+}
+
+public final class DefaultLoadSosoPickUsecase: LoadSosoPickUsecase {
+    
+    private let recommendationRepository: RecommendationRepository
+    
+    public init(recommendationRepository: RecommendationRepository) {
+        self.recommendationRepository = recommendationRepository
+    }
+    
+    public func execute() async throws -> [SosoPick] {
+        return try await recommendationRepository.fetchSosoPick()
+    }
+}

--- a/Projects/Domain/Recommendation/Testing/MockRecommendationRepository.swift
+++ b/Projects/Domain/Recommendation/Testing/MockRecommendationRepository.swift
@@ -1,0 +1,73 @@
+//
+//  MockRecommendationRepository.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import RecommendationDomain
+import BaseDomain
+
+public enum MockError: Error, Equatable {
+    case networkError
+    case serverError
+}
+
+public final class MockRecommendationRepository: RecommendationRepository {
+
+    public var fetchTodayDiscoveriesCallCount = 0
+    public var fetchTrendingFeedsCallCount = 0
+    public var fetchInterestFeedsCallCount = 0
+    public var fetchRecommendedNovelsCallCount = 0
+    public var fetchSosoPickCallCount = 0
+
+    public var fetchTodayDiscoveriesResult: Result<[TodayDiscovery], Error> = .success([])
+    public var fetchTrendingFeedsResult: Result<[TrendingFeed], Error> = .success([])
+    public var fetchInterestFeedsResult: Result<InterestFeedState, Error> = .success(.noInterestSettings)
+    public var fetchRecommendedNovelsResult: Result<RecommendedNovelState, Error> = .success(.noGenreSettings)
+    public var fetchSosoPickResult: Result<[SosoPick], Error> = .success([])
+
+    public init() {}
+
+    public func fetchTodayDiscoveries() async throws -> [TodayDiscovery] {
+        fetchTodayDiscoveriesCallCount += 1
+        switch fetchTodayDiscoveriesResult {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
+    }
+
+    public func fetchTrendingFeeds() async throws -> [TrendingFeed] {
+        fetchTrendingFeedsCallCount += 1
+        switch fetchTrendingFeedsResult {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
+    }
+
+    public func fetchInterestFeeds() async throws -> InterestFeedState {
+        fetchInterestFeedsCallCount += 1
+        switch fetchInterestFeedsResult {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
+    }
+
+    public func fetchRecommendedNovels() async throws -> RecommendedNovelState {
+        fetchRecommendedNovelsCallCount += 1
+        switch fetchRecommendedNovelsResult {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
+    }
+
+    public func fetchSosoPick() async throws -> [SosoPick] {
+        fetchSosoPickCallCount += 1
+        switch fetchSosoPickResult {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
+    }
+}

--- a/Projects/Domain/Recommendation/Tests/Entity/InterestFeedTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/InterestFeedTests.swift
@@ -1,0 +1,97 @@
+//
+//  InterestFeedTests.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import RecommendationDomain
+@testable import BaseDomain
+
+@Suite
+struct InterestFeedTests {
+
+    // MARK: - Helpers
+
+    private func makeInterestFeed(
+        novelID: NovelID = NovelID(1),
+        novelTitle: String = "테스트 소설",
+        novelRating: Float = 4.5,
+        novelRatingCount: Int = 100,
+        userComment: String = "재미있는 소설입니다"
+    ) -> InterestFeed {
+        InterestFeed(
+            novelID: novelID,
+            novelTitle: novelTitle,
+            novelThumbnailImage: nil,
+            novelRating: novelRating,
+            novelRatingCount: novelRatingCount,
+            user: Author(
+                userId: UserID(1),
+                nickname: "테스트유저",
+                profileImage: ImageWrapper(identifier: "profile")
+            ),
+            userComment: userComment
+        )
+    }
+
+    // MARK: - feeds 상태
+
+    @Test func `feeds 상태에서 피드 목록을 확인할 수 있다.`() {
+        let feed = makeInterestFeed(novelTitle: "소설 제목")
+        let state = InterestFeedState.feeds([feed])
+
+        guard case .feeds(let feeds) = state else {
+            Issue.record("feeds 상태여야 합니다")
+            return
+        }
+
+        #expect(feeds.count == 1)
+        #expect(feeds.first?.novelTitle == "소설 제목")
+    }
+
+    @Test func `feeds 상태에서 여러 피드를 포함할 수 있다.`() {
+        let feeds = [makeInterestFeed(), makeInterestFeed(), makeInterestFeed()]
+        let state = InterestFeedState.feeds(feeds)
+
+        guard case .feeds(let result) = state else {
+            Issue.record("feeds 상태여야 합니다")
+            return
+        }
+
+        #expect(result.count == 3)
+    }
+
+    @Test func `feeds 상태에서 피드 목록이 비어있을 수 있다.`() {
+        let state = InterestFeedState.feeds([])
+
+        guard case .feeds(let feeds) = state else {
+            Issue.record("feeds 상태여야 합니다")
+            return
+        }
+
+        #expect(feeds.isEmpty)
+    }
+
+    // MARK: - 비활성 상태
+
+    @Test func `관심 설정을 하지 않은 상태를 표현할 수 있다.`() {
+        let state = InterestFeedState.noInterestSettings
+
+        var isMatch = false
+        if case .noInterestSettings = state { isMatch = true }
+
+        #expect(isMatch)
+    }
+
+    @Test func `관련 피드가 없는 상태를 표현할 수 있다.`() {
+        let state = InterestFeedState.noAssociatedFeeds
+
+        var isMatch = false
+        if case .noAssociatedFeeds = state { isMatch = true }
+
+        #expect(isMatch)
+    }
+}

--- a/Projects/Domain/Recommendation/Tests/Entity/InterestFeedTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/InterestFeedTests.swift
@@ -39,7 +39,8 @@ struct InterestFeedTests {
 
     // MARK: - feeds 상태
 
-    @Test func `feeds 상태에서 피드 목록을 확인할 수 있다.`() {
+    @Test("feeds 상태에서 피드 목록을 확인할 수 있다")
+    func feedsStateContainsFeedList() {
         let feed = makeInterestFeed(novelTitle: "소설 제목")
         let state = InterestFeedState.feeds([feed])
 
@@ -52,7 +53,8 @@ struct InterestFeedTests {
         #expect(feeds.first?.novelTitle == "소설 제목")
     }
 
-    @Test func `feeds 상태에서 여러 피드를 포함할 수 있다.`() {
+    @Test("feeds 상태에서 여러 피드를 포함할 수 있다")
+    func feedsStateCanContainMultipleFeeds() {
         let feeds = [makeInterestFeed(), makeInterestFeed(), makeInterestFeed()]
         let state = InterestFeedState.feeds(feeds)
 
@@ -64,7 +66,8 @@ struct InterestFeedTests {
         #expect(result.count == 3)
     }
 
-    @Test func `feeds 상태에서 피드 목록이 비어있을 수 있다.`() {
+    @Test("feeds 상태에서 피드 목록이 비어있을 수 있다")
+    func feedsStateCanBeEmpty() {
         let state = InterestFeedState.feeds([])
 
         guard case .feeds(let feeds) = state else {
@@ -77,7 +80,8 @@ struct InterestFeedTests {
 
     // MARK: - 비활성 상태
 
-    @Test func `관심 설정을 하지 않은 상태를 표현할 수 있다.`() {
+    @Test("관심 설정을 하지 않은 상태를 표현할 수 있다")
+    func canRepresentNoInterestSettingsState() {
         let state = InterestFeedState.noInterestSettings
 
         var isMatch = false
@@ -86,7 +90,8 @@ struct InterestFeedTests {
         #expect(isMatch)
     }
 
-    @Test func `관련 피드가 없는 상태를 표현할 수 있다.`() {
+    @Test("관련 피드가 없는 상태를 표현할 수 있다")
+    func canRepresentNoAssociatedFeedsState() {
         let state = InterestFeedState.noAssociatedFeeds
 
         var isMatch = false

--- a/Projects/Domain/Recommendation/Tests/Entity/RecommendedNovelTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/RecommendedNovelTests.swift
@@ -34,7 +34,8 @@ struct RecommendedNovelTests {
 
     // MARK: - novels 상태
 
-    @Test func `novels 상태에서 소설 목록을 확인할 수 있다.`() {
+    @Test("novels 상태에서 소설 목록을 확인할 수 있다")
+    func novelsStateContainsNovelList() {
         let novel = makeRecommendedNovel(novelTitle: "판타지 소설")
         let state = RecommendedNovelState.novels([novel])
 
@@ -47,7 +48,8 @@ struct RecommendedNovelTests {
         #expect(novels.first?.novelTitle == "판타지 소설")
     }
 
-    @Test func `novels 상태에서 여러 소설을 포함할 수 있다.`() {
+    @Test("novels 상태에서 여러 소설을 포함할 수 있다")
+    func novelsStateCanContainMultipleNovels() {
         let novels = [makeRecommendedNovel(), makeRecommendedNovel(), makeRecommendedNovel()]
         let state = RecommendedNovelState.novels(novels)
 
@@ -59,7 +61,8 @@ struct RecommendedNovelTests {
         #expect(result.count == 3)
     }
 
-    @Test func `novels 상태에서 소설 목록이 비어있을 수 있다.`() {
+    @Test("novels 상태에서 소설 목록이 비어있을 수 있다")
+    func novelsStateCanBeEmpty() {
         let state = RecommendedNovelState.novels([])
 
         guard case .novels(let novels) = state else {
@@ -72,7 +75,8 @@ struct RecommendedNovelTests {
 
     // MARK: - 비활성 상태
 
-    @Test func `선호 장르가 미설정된 상태를 표현할 수 있다.`() {
+    @Test("선호 장르가 미설정된 상태를 표현할 수 있다")
+    func canRepresentNoGenreSettingsState() {
         let state = RecommendedNovelState.noGenreSettings
 
         var isMatch = false
@@ -83,7 +87,8 @@ struct RecommendedNovelTests {
 
     // MARK: - RecommendedNovel 속성
 
-    @Test func `소설에 여러 저자를 담을 수 있다.`() {
+    @Test("소설에 여러 저자를 담을 수 있다")
+    func novelCanContainMultipleAuthors() {
         let authors = ["작가A", "작가B", "작가C"]
         let novel = makeRecommendedNovel(novelAuthors: authors)
 
@@ -91,7 +96,8 @@ struct RecommendedNovelTests {
         #expect(novel.novelAuthors == authors)
     }
 
-    @Test func `소설의 관심 수와 평가 수를 포함한다.`() {
+    @Test("소설의 관심 수와 평가 수를 포함한다")
+    func novelIncludesInterestAndRatingCount() {
         let novel = makeRecommendedNovel(interestCount: 123, ratingCount: 456)
 
         #expect(novel.interestCount == 123)

--- a/Projects/Domain/Recommendation/Tests/Entity/RecommendedNovelTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/RecommendedNovelTests.swift
@@ -1,0 +1,100 @@
+//
+//  RecommendedNovelTests.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import RecommendationDomain
+@testable import BaseDomain
+
+@Suite
+struct RecommendedNovelTests {
+
+    // MARK: - Helpers
+
+    private func makeRecommendedNovel(
+        novelID: NovelID = NovelID(1),
+        novelTitle: String = "추천 소설",
+        novelAuthors: [String] = ["작가명"],
+        interestCount: Int = 50,
+        ratingCount: Int = 200
+    ) -> RecommendedNovel {
+        RecommendedNovel(
+            novelID: novelID,
+            novelTitle: novelTitle,
+            novelThumbnailImage: nil,
+            novelAuthors: novelAuthors,
+            interestCount: interestCount,
+            ratingCount: ratingCount
+        )
+    }
+
+    // MARK: - novels 상태
+
+    @Test func `novels 상태에서 소설 목록을 확인할 수 있다.`() {
+        let novel = makeRecommendedNovel(novelTitle: "판타지 소설")
+        let state = RecommendedNovelState.novels([novel])
+
+        guard case .novels(let novels) = state else {
+            Issue.record("novels 상태여야 합니다")
+            return
+        }
+
+        #expect(novels.count == 1)
+        #expect(novels.first?.novelTitle == "판타지 소설")
+    }
+
+    @Test func `novels 상태에서 여러 소설을 포함할 수 있다.`() {
+        let novels = [makeRecommendedNovel(), makeRecommendedNovel(), makeRecommendedNovel()]
+        let state = RecommendedNovelState.novels(novels)
+
+        guard case .novels(let result) = state else {
+            Issue.record("novels 상태여야 합니다")
+            return
+        }
+
+        #expect(result.count == 3)
+    }
+
+    @Test func `novels 상태에서 소설 목록이 비어있을 수 있다.`() {
+        let state = RecommendedNovelState.novels([])
+
+        guard case .novels(let novels) = state else {
+            Issue.record("novels 상태여야 합니다")
+            return
+        }
+
+        #expect(novels.isEmpty)
+    }
+
+    // MARK: - 비활성 상태
+
+    @Test func `선호 장르가 미설정된 상태를 표현할 수 있다.`() {
+        let state = RecommendedNovelState.noGenreSettings
+
+        var isMatch = false
+        if case .noGenreSettings = state { isMatch = true }
+
+        #expect(isMatch)
+    }
+
+    // MARK: - RecommendedNovel 속성
+
+    @Test func `소설에 여러 저자를 담을 수 있다.`() {
+        let authors = ["작가A", "작가B", "작가C"]
+        let novel = makeRecommendedNovel(novelAuthors: authors)
+
+        #expect(novel.novelAuthors.count == 3)
+        #expect(novel.novelAuthors == authors)
+    }
+
+    @Test func `소설의 관심 수와 평가 수를 포함한다.`() {
+        let novel = makeRecommendedNovel(interestCount: 123, ratingCount: 456)
+
+        #expect(novel.interestCount == 123)
+        #expect(novel.ratingCount == 456)
+    }
+}

--- a/Projects/Domain/Recommendation/Tests/Entity/SosoPickTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/SosoPickTests.swift
@@ -1,0 +1,46 @@
+//
+//  SosoPickTests.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import RecommendationDomain
+@testable import BaseDomain
+
+@Suite
+struct SosoPickTests {
+
+    // MARK: - Helpers
+
+    private func makeSosoPick(
+        novelID: NovelID = NovelID(1),
+        novelTitle: String = "소소 픽 소설",
+        novelThumbnailimage: URL? = nil
+    ) -> SosoPick {
+        SosoPick(
+            novelID: novelID,
+            novelTitle: novelTitle,
+            novelThumbnailimage: novelThumbnailimage
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test func `소소픽을 생성할 수 있다.`() {
+        let pick = makeSosoPick(novelID: NovelID(42), novelTitle: "추천 소설")
+
+        #expect(pick.novelID == NovelID(42))
+        #expect(pick.novelTitle == "추천 소설")
+    }
+
+    @Test func `썸네일 이미지를 포함하여 생성할 수 있다.`() {
+        let url = URL(string: "https://example.com/thumbnail.jpg")
+        let pick = makeSosoPick(novelThumbnailimage: url)
+
+        #expect(pick.novelThumbnailimage != nil)
+    }
+}

--- a/Projects/Domain/Recommendation/Tests/Entity/SosoPickTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/SosoPickTests.swift
@@ -30,14 +30,16 @@ struct SosoPickTests {
 
     // MARK: - Tests
 
-    @Test func `소소픽을 생성할 수 있다.`() {
+    @Test("소소픽을 생성할 수 있다")
+    func canCreateSosoPick() {
         let pick = makeSosoPick(novelID: NovelID(42), novelTitle: "추천 소설")
 
         #expect(pick.novelID == NovelID(42))
         #expect(pick.novelTitle == "추천 소설")
     }
 
-    @Test func `썸네일 이미지를 포함하여 생성할 수 있다.`() {
+    @Test("썸네일 이미지를 포함하여 생성할 수 있다")
+    func canCreateSosoPickWithThumbnailImage() {
         let url = URL(string: "https://example.com/thumbnail.jpg")
         let pick = makeSosoPick(novelThumbnailimage: url)
 

--- a/Projects/Domain/Recommendation/Tests/Entity/TodayDiscoveryTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/TodayDiscoveryTests.swift
@@ -40,7 +40,8 @@ struct TodayDiscoveryTests {
 
     // MARK: - Content 타입
 
-    @Test func `novel 타입으로 오늘의 발견을 생성할 수 있다.`() {
+    @Test("novel 타입으로 오늘의 발견을 생성할 수 있다")
+    func canCreateTodayDiscoveryWithNovelType() {
         let discovery = makeTodayDiscovery(content: .novel(description: "흥미로운 소설입니다"))
 
         var isMatch = false
@@ -49,7 +50,8 @@ struct TodayDiscoveryTests {
         #expect(isMatch)
     }
 
-    @Test func `userComment 타입으로 오늘의 발견을 생성할 수 있다.`() {
+    @Test("userComment 타입으로 오늘의 발견을 생성할 수 있다")
+    func canCreateTodayDiscoveryWithUserCommentType() {
         let discovery = makeTodayDiscovery(
             content: .userComment(user: makeAuthor(), comment: "강추합니다!")
         )
@@ -60,7 +62,8 @@ struct TodayDiscoveryTests {
         #expect(isMatch)
     }
 
-    @Test func `novel 타입에서 설명 텍스트를 가져올 수 있다.`() {
+    @Test("novel 타입에서 설명 텍스트를 가져올 수 있다")
+    func canGetDescriptionFromNovelType() {
         let description = "이 소설은 매우 흥미롭습니다"
         let discovery = makeTodayDiscovery(content: .novel(description: description))
 
@@ -72,7 +75,8 @@ struct TodayDiscoveryTests {
         #expect(result == description)
     }
 
-    @Test func `userComment 타입에서 유저 정보와 한마디를 가져올 수 있다.`() {
+    @Test("userComment 타입에서 유저 정보와 한마디를 가져올 수 있다")
+    func canGetUserInfoAndCommentFromUserCommentType() {
         let author = makeAuthor()
         let comment = "이 작품은 정말 최고입니다"
         let discovery = makeTodayDiscovery(

--- a/Projects/Domain/Recommendation/Tests/Entity/TodayDiscoveryTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/TodayDiscoveryTests.swift
@@ -1,0 +1,90 @@
+//
+//  TodayDiscoveryTests.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import RecommendationDomain
+@testable import BaseDomain
+
+@Suite
+struct TodayDiscoveryTests {
+
+    // MARK: - Helpers
+
+    private func makeAuthor() -> Author {
+        Author(
+            userId: UserID(1),
+            nickname: "테스트유저",
+            profileImage: ImageWrapper(identifier: "profile")
+        )
+    }
+
+    private func makeTodayDiscovery(
+        novelID: NovelID = NovelID(1),
+        novelTitle: String = "오늘의 발견 소설",
+        novelThumbnailImage: URL? = nil,
+        content: TodayDiscovery.Content = .novel(description: "소설 설명")
+    ) -> TodayDiscovery {
+        TodayDiscovery(
+            novelID: novelID,
+            novelTitle: novelTitle,
+            novelThumbnailImage: novelThumbnailImage,
+            content: content
+        )
+    }
+
+    // MARK: - Content 타입
+
+    @Test func `novel 타입으로 오늘의 발견을 생성할 수 있다.`() {
+        let discovery = makeTodayDiscovery(content: .novel(description: "흥미로운 소설입니다"))
+
+        var isMatch = false
+        if case .novel = discovery.content { isMatch = true }
+
+        #expect(isMatch)
+    }
+
+    @Test func `userComment 타입으로 오늘의 발견을 생성할 수 있다.`() {
+        let discovery = makeTodayDiscovery(
+            content: .userComment(user: makeAuthor(), comment: "강추합니다!")
+        )
+
+        var isMatch = false
+        if case .userComment = discovery.content { isMatch = true }
+
+        #expect(isMatch)
+    }
+
+    @Test func `novel 타입에서 설명 텍스트를 가져올 수 있다.`() {
+        let description = "이 소설은 매우 흥미롭습니다"
+        let discovery = makeTodayDiscovery(content: .novel(description: description))
+
+        guard case .novel(let result) = discovery.content else {
+            Issue.record("novel 타입이어야 합니다")
+            return
+        }
+
+        #expect(result == description)
+    }
+
+    @Test func `userComment 타입에서 유저 정보와 한마디를 가져올 수 있다.`() {
+        let author = makeAuthor()
+        let comment = "이 작품은 정말 최고입니다"
+        let discovery = makeTodayDiscovery(
+            content: .userComment(user: author, comment: comment)
+        )
+
+        guard case .userComment(let user, let result) = discovery.content else {
+            Issue.record("userComment 타입이어야 합니다")
+            return
+        }
+
+        #expect(user.nickname == author.nickname)
+        #expect(result == comment)
+    }
+}

--- a/Projects/Domain/Recommendation/Tests/Entity/TrendingFeedTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/TrendingFeedTests.swift
@@ -1,0 +1,54 @@
+//
+//  TrendingFeedTests.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import RecommendationDomain
+@testable import BaseDomain
+
+@Suite
+struct TrendingFeedTests {
+
+    // MARK: - Helpers
+
+    private func makeTrendingFeed(
+        feedID: FeedID = FeedID(1),
+        description: String = "지금 뜨는 글 내용",
+        likeCount: Int = 10,
+        commentCount: Int = 5
+    ) -> TrendingFeed {
+        TrendingFeed(
+            feedID: feedID,
+            description: description,
+            likeCount: likeCount,
+            commentCount: commentCount
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test func `지금 뜨는 글을 생성할 수 있다.`() {
+        let feed = makeTrendingFeed(feedID: FeedID(99), description: "인기 글 내용")
+
+        #expect(feed.feedID == FeedID(99))
+        #expect(feed.description == "인기 글 내용")
+    }
+
+    @Test func `좋아요 수와 댓글 수를 포함한다.`() {
+        let feed = makeTrendingFeed(likeCount: 150, commentCount: 30)
+
+        #expect(feed.likeCount == 150)
+        #expect(feed.commentCount == 30)
+    }
+
+    @Test func `서로 다른 feedID로 구별할 수 있다.`() {
+        let feed1 = makeTrendingFeed(feedID: FeedID(1))
+        let feed2 = makeTrendingFeed(feedID: FeedID(2))
+
+        #expect(feed1.feedID != feed2.feedID)
+    }
+}

--- a/Projects/Domain/Recommendation/Tests/Entity/TrendingFeedTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Entity/TrendingFeedTests.swift
@@ -31,21 +31,24 @@ struct TrendingFeedTests {
 
     // MARK: - Tests
 
-    @Test func `지금 뜨는 글을 생성할 수 있다.`() {
+    @Test("지금 뜨는 글을 생성할 수 있다")
+    func canCreateTrendingFeed() {
         let feed = makeTrendingFeed(feedID: FeedID(99), description: "인기 글 내용")
 
         #expect(feed.feedID == FeedID(99))
         #expect(feed.description == "인기 글 내용")
     }
 
-    @Test func `좋아요 수와 댓글 수를 포함한다.`() {
+    @Test("좋아요 수와 댓글 수를 포함한다")
+    func includesLikeCountAndCommentCount() {
         let feed = makeTrendingFeed(likeCount: 150, commentCount: 30)
 
         #expect(feed.likeCount == 150)
         #expect(feed.commentCount == 30)
     }
 
-    @Test func `서로 다른 feedID로 구별할 수 있다.`() {
+    @Test("서로 다른 feedID로 구별할 수 있다")
+    func canDistinguishByDifferentFeedIDs() {
         let feed1 = makeTrendingFeed(feedID: FeedID(1))
         let feed2 = makeTrendingFeed(feedID: FeedID(2))
 

--- a/Projects/Domain/Recommendation/Tests/Usecase/LoadHomeDataUsecaseTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Usecase/LoadHomeDataUsecaseTests.swift
@@ -13,7 +13,24 @@ import Testing
 
 @Suite
 struct LoadHomeDataUsecaseTests {
-
+    
+    @Test("네 가지 API가 모두 호출된다")
+    func callsAllFourApis() async {
+        let mock = MockRecommendationRepository()
+        mock.fetchTodayDiscoveriesResult = .success([])
+        mock.fetchTrendingFeedsResult = .success([])
+        mock.fetchInterestFeedsResult = .success(.feeds([]))
+        mock.fetchRecommendedNovelsResult = .success(.novels([]))
+        
+        let usecase = DefaultLoadDataUsecase(repository: mock)
+        _ = try? await usecase.execute()
+        
+        #expect(mock.fetchTodayDiscoveriesCallCount == 1)
+        #expect(mock.fetchTrendingFeedsCallCount == 1)
+        #expect(mock.fetchInterestFeedsCallCount == 1)
+        #expect(mock.fetchRecommendedNovelsCallCount == 1)
+    }
+    
     @Test("모든 데이터를 성공적으로 불러온다")
     func loadsAllDataSuccessfully() async throws {
         let mock = MockRecommendationRepository()
@@ -21,82 +38,39 @@ struct LoadHomeDataUsecaseTests {
         mock.fetchTrendingFeedsResult = .success([makeTrendingFeed()])
         mock.fetchInterestFeedsResult = .success(.feeds([]))
         mock.fetchRecommendedNovelsResult = .success(.novels([]))
-
+        
         let usecase = DefaultLoadDataUsecase(repository: mock)
-        let homeData = await usecase.execute()
-
-        let discoveries = try homeData.todayDiscoveries.get()
-        let feeds = try homeData.trendingFeeds.get()
-        let interestState = try homeData.interestFeedState.get()
-        let novelState = try homeData.recommendedNovelState.get()
-
-        #expect(discoveries.count == 1)
-        #expect(feeds.count == 1)
-
-        var isFeeds = false
-        if case .feeds = interestState { isFeeds = true }
-        #expect(isFeeds)
-
-        var isNovels = false
-        if case .novels = novelState { isNovels = true }
-        #expect(isNovels)
+        let homeData = try await usecase.execute()
+        
+        #expect(homeData.todayDiscoveries.count == 1)
+        #expect(homeData.trendingFeeds.count == 1)
     }
-
-    @Test("todayDiscoveries 실패 시 해당 필드만 failure로 반환한다")
-    func returnsTodayDiscoveriesFailureWhenItFails() async {
+    
+    @Test("todayDiscoveries 실패 시 전체를 실패로 반환한다")
+    func throwsWhenTodayDiscoveriesFails() async {
         let mock = MockRecommendationRepository()
         mock.fetchTodayDiscoveriesResult = .failure(MockError.networkError)
-
+        
         let usecase = DefaultLoadDataUsecase(repository: mock)
-        let homeData = await usecase.execute()
-
-        #expect(throws: MockError.networkError) {
-            try homeData.todayDiscoveries.get()
+        
+        await #expect(throws: MockError.networkError) {
+            try await usecase.execute()
         }
     }
-
-    @Test("특정 API 실패 시 나머지 필드는 성공으로 반환한다")
-    func returnsRemainingFieldsSuccessWhenOneApiFails() async throws {
+    
+    @Test("특정 API 실패 시 전체를 실패로 반환한다")
+    func throwsWhenAnyApiFails() async {
         let mock = MockRecommendationRepository()
-        mock.fetchTodayDiscoveriesResult = .failure(MockError.networkError)
-        mock.fetchTrendingFeedsResult = .success([makeTrendingFeed()])
+        mock.fetchTodayDiscoveriesResult = .success([makeTodayDiscovery()])
+        mock.fetchTrendingFeedsResult = .failure(MockError.networkError)
         mock.fetchInterestFeedsResult = .success(.noInterestSettings)
         mock.fetchRecommendedNovelsResult = .success(.noGenreSettings)
-
+        
         let usecase = DefaultLoadDataUsecase(repository: mock)
-        let homeData = await usecase.execute()
-
-        // todayDiscoveries만 실패
-        #expect(throws: MockError.networkError) {
-            try homeData.todayDiscoveries.get()
+        
+        await #expect(throws: MockError.networkError) {
+            try await usecase.execute()
         }
-
-        // 나머지 필드는 성공
-        let feeds = try homeData.trendingFeeds.get()
-        #expect(feeds.count == 1)
-
-        let interestState = try homeData.interestFeedState.get()
-        var isNoInterest = false
-        if case .noInterestSettings = interestState { isNoInterest = true }
-        #expect(isNoInterest)
-
-        let novelState = try homeData.recommendedNovelState.get()
-        var isNoGenre = false
-        if case .noGenreSettings = novelState { isNoGenre = true }
-        #expect(isNoGenre)
-    }
-
-    @Test("네 가지 API가 모두 동시에 호출된다")
-    func callsAllFourApisSimultaneously() async {
-        let mock = MockRecommendationRepository()
-
-        let usecase = DefaultLoadDataUsecase(repository: mock)
-        _ = await usecase.execute()
-
-        #expect(mock.fetchTodayDiscoveriesCallCount == 1)
-        #expect(mock.fetchTrendingFeedsCallCount == 1)
-        #expect(mock.fetchInterestFeedsCallCount == 1)
-        #expect(mock.fetchRecommendedNovelsCallCount == 1)
     }
 }
 
@@ -109,7 +83,7 @@ extension LoadHomeDataUsecaseTests {
             content: .novel(description: "소설 설명")
         )
     }
-
+    
     private func makeTrendingFeed() -> TrendingFeed {
         TrendingFeed(
             feedID: FeedID(1),

--- a/Projects/Domain/Recommendation/Tests/Usecase/LoadHomeDataUsecaseTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Usecase/LoadHomeDataUsecaseTests.swift
@@ -1,0 +1,117 @@
+//
+//  LoadHomeDataUsecaseTests.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import RecommendationDomain
+@testable import BaseDomain
+@testable import RecommendationDomainTesting
+
+@Suite
+struct LoadHomeDataUsecaseTests {
+
+    @Test func `모든 데이터를 성공적으로 불러온다.`() async throws {
+        let mock = MockRecommendationRepository()
+        mock.fetchTodayDiscoveriesResult = .success([makeTodayDiscovery()])
+        mock.fetchTrendingFeedsResult = .success([makeTrendingFeed()])
+        mock.fetchInterestFeedsResult = .success(.feeds([]))
+        mock.fetchRecommendedNovelsResult = .success(.novels([]))
+
+        let usecase = DefaultLoadDataUsecase(repository: mock)
+        let homeData = await usecase.execute()
+
+        let discoveries = try homeData.todayDiscoveries.get()
+        let feeds = try homeData.trendingFeeds.get()
+        let interestState = try homeData.interestFeedState.get()
+        let novelState = try homeData.recommendedNovelState.get()
+
+        #expect(discoveries.count == 1)
+        #expect(feeds.count == 1)
+
+        var isFeeds = false
+        if case .feeds = interestState { isFeeds = true }
+        #expect(isFeeds)
+
+        var isNovels = false
+        if case .novels = novelState { isNovels = true }
+        #expect(isNovels)
+    }
+
+    @Test func `todayDiscoveries 실패 시 해당 필드만 failure로 반환한다.`() async {
+        let mock = MockRecommendationRepository()
+        mock.fetchTodayDiscoveriesResult = .failure(MockError.networkError)
+
+        let usecase = DefaultLoadDataUsecase(repository: mock)
+        let homeData = await usecase.execute()
+
+        #expect(throws: MockError.networkError) {
+            try homeData.todayDiscoveries.get()
+        }
+    }
+
+    @Test func `특정 API 실패 시 나머지 필드는 성공으로 반환한다.`() async throws {
+        let mock = MockRecommendationRepository()
+        mock.fetchTodayDiscoveriesResult = .failure(MockError.networkError)
+        mock.fetchTrendingFeedsResult = .success([makeTrendingFeed()])
+        mock.fetchInterestFeedsResult = .success(.noInterestSettings)
+        mock.fetchRecommendedNovelsResult = .success(.noGenreSettings)
+
+        let usecase = DefaultLoadDataUsecase(repository: mock)
+        let homeData = await usecase.execute()
+
+        // todayDiscoveries만 실패
+        #expect(throws: MockError.networkError) {
+            try homeData.todayDiscoveries.get()
+        }
+
+        // 나머지 필드는 성공
+        let feeds = try homeData.trendingFeeds.get()
+        #expect(feeds.count == 1)
+
+        let interestState = try homeData.interestFeedState.get()
+        var isNoInterest = false
+        if case .noInterestSettings = interestState { isNoInterest = true }
+        #expect(isNoInterest)
+
+        let novelState = try homeData.recommendedNovelState.get()
+        var isNoGenre = false
+        if case .noGenreSettings = novelState { isNoGenre = true }
+        #expect(isNoGenre)
+    }
+
+    @Test func `네 가지 API가 모두 동시에 호출된다.`() async {
+        let mock = MockRecommendationRepository()
+
+        let usecase = DefaultLoadDataUsecase(repository: mock)
+        _ = await usecase.execute()
+
+        #expect(mock.fetchTodayDiscoveriesCallCount == 1)
+        #expect(mock.fetchTrendingFeedsCallCount == 1)
+        #expect(mock.fetchInterestFeedsCallCount == 1)
+        #expect(mock.fetchRecommendedNovelsCallCount == 1)
+    }
+}
+
+extension LoadHomeDataUsecaseTests {
+    private func makeTodayDiscovery() -> TodayDiscovery {
+        TodayDiscovery(
+            novelID: NovelID(1),
+            novelTitle: "오늘의 발견",
+            novelThumbnailImage: nil,
+            content: .novel(description: "소설 설명")
+        )
+    }
+
+    private func makeTrendingFeed() -> TrendingFeed {
+        TrendingFeed(
+            feedID: FeedID(1),
+            description: "뜨는 글 내용",
+            likeCount: 10,
+            commentCount: 3
+        )
+    }
+}

--- a/Projects/Domain/Recommendation/Tests/Usecase/LoadHomeDataUsecaseTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Usecase/LoadHomeDataUsecaseTests.swift
@@ -14,7 +14,8 @@ import Testing
 @Suite
 struct LoadHomeDataUsecaseTests {
 
-    @Test func `모든 데이터를 성공적으로 불러온다.`() async throws {
+    @Test("모든 데이터를 성공적으로 불러온다")
+    func loadsAllDataSuccessfully() async throws {
         let mock = MockRecommendationRepository()
         mock.fetchTodayDiscoveriesResult = .success([makeTodayDiscovery()])
         mock.fetchTrendingFeedsResult = .success([makeTrendingFeed()])
@@ -41,7 +42,8 @@ struct LoadHomeDataUsecaseTests {
         #expect(isNovels)
     }
 
-    @Test func `todayDiscoveries 실패 시 해당 필드만 failure로 반환한다.`() async {
+    @Test("todayDiscoveries 실패 시 해당 필드만 failure로 반환한다")
+    func returnsTodayDiscoveriesFailureWhenItFails() async {
         let mock = MockRecommendationRepository()
         mock.fetchTodayDiscoveriesResult = .failure(MockError.networkError)
 
@@ -53,7 +55,8 @@ struct LoadHomeDataUsecaseTests {
         }
     }
 
-    @Test func `특정 API 실패 시 나머지 필드는 성공으로 반환한다.`() async throws {
+    @Test("특정 API 실패 시 나머지 필드는 성공으로 반환한다")
+    func returnsRemainingFieldsSuccessWhenOneApiFails() async throws {
         let mock = MockRecommendationRepository()
         mock.fetchTodayDiscoveriesResult = .failure(MockError.networkError)
         mock.fetchTrendingFeedsResult = .success([makeTrendingFeed()])
@@ -83,7 +86,8 @@ struct LoadHomeDataUsecaseTests {
         #expect(isNoGenre)
     }
 
-    @Test func `네 가지 API가 모두 동시에 호출된다.`() async {
+    @Test("네 가지 API가 모두 동시에 호출된다")
+    func callsAllFourApisSimultaneously() async {
         let mock = MockRecommendationRepository()
 
         let usecase = DefaultLoadDataUsecase(repository: mock)

--- a/Projects/Domain/Recommendation/Tests/Usecase/LoadSosoPickUsecaseTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Usecase/LoadSosoPickUsecaseTests.swift
@@ -14,7 +14,8 @@ import Testing
 @Suite
 struct LoadSosoPickUsecaseTests {
 
-    @Test func `소소픽을 성공적으로 불러온다.`() async throws {
+    @Test("소소픽을 성공적으로 불러온다")
+    func loadsSosoPickSuccessfully() async throws {
         let mock = MockRecommendationRepository()
         let expectedPicks = [makeSosoPick(novelID: NovelID(1)), makeSosoPick(novelID: NovelID(2))]
         mock.fetchSosoPickResult = .success(expectedPicks)
@@ -26,7 +27,8 @@ struct LoadSosoPickUsecaseTests {
         #expect(mock.fetchSosoPickCallCount == 1)
     }
 
-    @Test func `소소픽 목록이 비어있어도 정상적으로 반환한다.`() async throws {
+    @Test("소소픽 목록이 비어있어도 정상적으로 반환한다")
+    func returnsEmptySosoPickListNormally() async throws {
         let mock = MockRecommendationRepository()
         mock.fetchSosoPickResult = .success([])
 
@@ -36,7 +38,8 @@ struct LoadSosoPickUsecaseTests {
         #expect(result.isEmpty)
     }
 
-    @Test func `소소픽 불러오기에 실패하면 에러를 던진다.`() async {
+    @Test("소소픽 불러오기에 실패하면 에러를 던진다")
+    func throwsErrorWhenLoadSosoPickFails() async {
         let mock = MockRecommendationRepository()
         mock.fetchSosoPickResult = .failure(MockError.networkError)
 

--- a/Projects/Domain/Recommendation/Tests/Usecase/LoadSosoPickUsecaseTests.swift
+++ b/Projects/Domain/Recommendation/Tests/Usecase/LoadSosoPickUsecaseTests.swift
@@ -1,0 +1,59 @@
+//
+//  LoadSosoPickUsecaseTests.swift
+//  RecommendationDomain
+//
+//  Created by Seoyeon Choi on 2/20/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import RecommendationDomain
+@testable import BaseDomain
+@testable import RecommendationDomainTesting
+
+@Suite
+struct LoadSosoPickUsecaseTests {
+
+    @Test func `소소픽을 성공적으로 불러온다.`() async throws {
+        let mock = MockRecommendationRepository()
+        let expectedPicks = [makeSosoPick(novelID: NovelID(1)), makeSosoPick(novelID: NovelID(2))]
+        mock.fetchSosoPickResult = .success(expectedPicks)
+
+        let usecase = DefaultLoadSosoPickUsecase(recommendationRepository: mock)
+        let result = try await usecase.execute()
+
+        #expect(result.count == 2)
+        #expect(mock.fetchSosoPickCallCount == 1)
+    }
+
+    @Test func `소소픽 목록이 비어있어도 정상적으로 반환한다.`() async throws {
+        let mock = MockRecommendationRepository()
+        mock.fetchSosoPickResult = .success([])
+
+        let usecase = DefaultLoadSosoPickUsecase(recommendationRepository: mock)
+        let result = try await usecase.execute()
+
+        #expect(result.isEmpty)
+    }
+
+    @Test func `소소픽 불러오기에 실패하면 에러를 던진다.`() async {
+        let mock = MockRecommendationRepository()
+        mock.fetchSosoPickResult = .failure(MockError.networkError)
+
+        let usecase = DefaultLoadSosoPickUsecase(recommendationRepository: mock)
+
+        await #expect(throws: MockError.networkError) {
+            try await usecase.execute()
+        }
+    }
+}
+
+extension LoadSosoPickUsecaseTests {
+    private func makeSosoPick(novelID: NovelID = NovelID(1)) -> SosoPick {
+        SosoPick(
+            novelID: novelID,
+            novelTitle: "소소 픽 소설",
+            novelThumbnailimage: nil
+        )
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -69,9 +69,6 @@ extension Project {
         
         // Testing
         if targets.contains(.testing) {
-            var testingDeps = internalDependencies + externalDependencies
-            testingDeps.append(.target(name: name))
-
             allTargets.append(
                 .target(
                     name: "\(name)Testing",
@@ -82,7 +79,7 @@ extension Project {
                     infoPlist: infoPlist,
                     sources: ["Testing/**"],
                     resources: [],
-                    dependencies: testingDeps
+                    dependencies: [.target(name: name)]
                 )
             )
         }
@@ -109,7 +106,7 @@ extension Project {
                 )
             )
         }
-        
+
         return allTargets
     }
     


### PR DESCRIPTION
## 💡 Issue
<!-- closed #1 -->
- closed #34 
<br>

## 💭 Summary
<!-- 작업에 대한 간단한 소개 -->
Recommendation Domain 모듈을 구현했습니다. 
<br>

## 🔑 Key Changes
<!-- 작업에 대한 구체적인 설명 -->
###  `RecommendationDomain` 유지 결정

지난 회의에서 RecommendationDomain을 제거하고
FeedDomain / NovelDomain으로 통합하는 방향도 논의되었습니다.

하지만 다음과 같은 이유로 `RecommendationDomain`을 유지하기로 결정했습니다.
- 추천 로직은 Feed / Novel과는 다른 책임을 가짐
- 추천 모델을 기존 도메인에 포함시키면 경계가 흐려질 가능성이 있음
- 향후 추천 알고리즘 변경 및 확장 시 독립적인 수정이 가능함

Recommendation은 단순 데이터 조회가 아니라
추천이라는 비즈니스 맥락을 가진 별도 도메인 영역으로 보는 것이
책임 분리 측면에서 더 적절하다고 판단했습니다.
<br>

## 📱 Simulation
<!-- 작업에 대한 UI 시뮬레이터 -->

<br>

## 🧑‍🧒‍🧒 To Reviewer
<!-- 리뷰어에게 전달할 내용 -->

<br>

## ※ Reference
<!-- 작업 시 참고한 레퍼런스 -->
