### PR TITLE
[Feat] #48 - Profile Domain Module 구현

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
@@ -36,6 +36,7 @@ public enum ModuleType {
         case novelReview
         case setting
         case notification
+        case profile
         case social
         
         public var name: String {
@@ -50,6 +51,7 @@ public enum ModuleType {
             case .novelReview: "NovelReviewDomain"
             case .setting: "SettingDomain"
             case .notification: "NotificationDomain"
+            case .profile: "ProfileDomain"
             case .social: "SocialDomain"
             }
         }

--- a/Projects/Domain/Novel/Sources/Entity/Novel/RegisteredNovelStats.swift
+++ b/Projects/Domain/Novel/Sources/Entity/Novel/RegisteredNovelStats.swift
@@ -1,0 +1,16 @@
+//
+//  RegisteredNovelStats.swift
+//  NovelDomain
+//
+//  Created by Seoyeon Choi on 2/27/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct RegisteredNovelStats {
+    public let interest: Int
+    public let watching: Int
+    public let watched: Int
+    public let quit: Int
+}

--- a/Projects/Domain/Novel/Sources/Repository/NovelRepository.swift
+++ b/Projects/Domain/Novel/Sources/Repository/NovelRepository.swift
@@ -30,4 +30,6 @@ public protocol NovelRepository {
     /// 필터 조건을 적용하여 서재 작품을 페이지네이션 형태로 반환한다.
     func fetchMyLibraryNovels(_ filter: MyLibraryFilter) async throws -> (Paginated<LibraryNovel>, Int)
     func fetchUserLibraryNovels(id: UserID) async throws -> (Paginated<LibraryNovel>, Int)
+    
+    func fetchRegisteredNovelStats() async throws -> RegisteredNovelStats
 }

--- a/Projects/Domain/Novel/Sources/Usecase/LoadRegisteredNovelStatsUsecase.swift
+++ b/Projects/Domain/Novel/Sources/Usecase/LoadRegisteredNovelStatsUsecase.swift
@@ -1,0 +1,26 @@
+//
+//  LoadRegisteredNovelStatsUsecase.swift
+//  NovelDomain
+//
+//  Created by Seoyeon Choi on 2/27/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoadRegisteredNovelStatsUsecase {
+    func execute() async throws -> RegisteredNovelStats
+}
+
+public final class DefaultLoadRegisteredNovelStatsUsecase: LoadRegisteredNovelStatsUsecase {
+    
+    private let novelRepository: NovelRepository
+    
+    public init(novelRepository: NovelRepository) {
+        self.novelRepository = novelRepository
+    }
+    
+    public func execute() async throws -> RegisteredNovelStats {
+        try await novelRepository.fetchRegisteredNovelStats()
+    }
+}

--- a/Projects/Domain/Novel/Testing/Mock/MockNovelRepository.swift
+++ b/Projects/Domain/Novel/Testing/Mock/MockNovelRepository.swift
@@ -19,6 +19,7 @@ public final class MockNovelRepository: NovelRepository {
     public var searchByFilterResult: Result<(Paginated<Novel>, Int), Error>!
     public var fetchMyLibraryResult: Result<(Paginated<LibraryNovel>, Int), Error>!
     public var fetchUserLibraryResult: Result<(Paginated<LibraryNovel>, Int), Error>!
+    public var fetchRegisteredNovelStatsResult: Result<RegisteredNovelStats, Error>!
 
     public private(set) var fetchedNovelIDs: [NovelID] = []
     public private(set) var addedInterestIDs: [NovelID] = []
@@ -29,6 +30,7 @@ public final class MockNovelRepository: NovelRepository {
     public private(set) var lastSearchFilter: SearchFilter?
     public private(set) var fetchedMyLibraryFilters: [MyLibraryFilter] = []
     public private(set) var fetchedUserLibraryIDs: [UserID] = []
+    public private(set) var fetchRegisteredNovelStatsCallCount = 0
 
     public init() {}
 
@@ -67,5 +69,10 @@ public final class MockNovelRepository: NovelRepository {
     public func fetchUserLibraryNovels(id: UserID) async throws -> (Paginated<LibraryNovel>, Int) {
         fetchedUserLibraryIDs.append(id)
         return try fetchUserLibraryResult.get()
+    }
+
+    public func fetchRegisteredNovelStats() async throws -> RegisteredNovelStats {
+        fetchRegisteredNovelStatsCallCount += 1
+        return try fetchRegisteredNovelStatsResult.get()
     }
 }

--- a/Projects/Domain/Novel/Tests/Entity/RegisteredNovelStatsTests.swift
+++ b/Projects/Domain/Novel/Tests/Entity/RegisteredNovelStatsTests.swift
@@ -1,0 +1,47 @@
+//
+//  RegisteredNovelStatsTests.swift
+//  NovelDomain
+//
+//  Created by Seoyeon Choi on 2/27/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+
+@testable import NovelDomain
+
+@Suite
+struct RegisteredNovelStatsTests {
+
+    @Test("RegisteredNovelStats를 정상적으로 생성한다")
+    func createStats() {
+        let stats = makeStats()
+
+        #expect(stats.interest == 10)
+        #expect(stats.watching == 20)
+        #expect(stats.watched == 30)
+        #expect(stats.quit == 5)
+    }
+
+    @Test("모든 카운트가 0인 경우에도 생성된다")
+    func createStatsWithZeroCounts() {
+        let stats = makeStats(interest: 0, watching: 0, watched: 0, quit: 0)
+
+        #expect(stats.interest == 0)
+        #expect(stats.watching == 0)
+        #expect(stats.watched == 0)
+        #expect(stats.quit == 0)
+    }
+}
+
+extension RegisteredNovelStatsTests {
+
+    private func makeStats(
+        interest: Int = 10,
+        watching: Int = 20,
+        watched: Int = 30,
+        quit: Int = 5
+    ) -> RegisteredNovelStats {
+        RegisteredNovelStats(interest: interest, watching: watching, watched: watched, quit: quit)
+    }
+}

--- a/Projects/Domain/Novel/Tests/Usecase/LoadRegisteredNovelStatsUsecaseTests.swift
+++ b/Projects/Domain/Novel/Tests/Usecase/LoadRegisteredNovelStatsUsecaseTests.swift
@@ -1,0 +1,69 @@
+//
+//  LoadRegisteredNovelStatsUsecaseTests.swift
+//  NovelDomain
+//
+//  Created by Seoyeon Choi on 2/27/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+
+@testable import NovelDomain
+@testable import BaseDomain
+import NovelDomainTesting
+
+@Suite
+struct LoadRegisteredNovelStatsUsecaseTests {
+
+    @Test("등록된 소설 통계를 정상적으로 불러온다")
+    func loadRegisteredNovelStatsSuccess() async throws {
+        let mock = MockNovelRepository()
+        let expected = makeStats()
+        mock.fetchRegisteredNovelStatsResult = .success(expected)
+
+        let usecase = DefaultLoadRegisteredNovelStatsUsecase(novelRepository: mock)
+        let result = try await usecase.execute()
+
+        #expect(result.interest == expected.interest)
+        #expect(result.watching == expected.watching)
+        #expect(result.watched == expected.watched)
+        #expect(result.quit == expected.quit)
+    }
+
+    @Test("Repository가 정확히 한 번 호출된다")
+    func repositoryCalledOnce() async throws {
+        let mock = MockNovelRepository()
+        mock.fetchRegisteredNovelStatsResult = .success(makeStats())
+
+        let usecase = DefaultLoadRegisteredNovelStatsUsecase(novelRepository: mock)
+        _ = try await usecase.execute()
+
+        #expect(mock.fetchRegisteredNovelStatsCallCount == 1)
+    }
+
+    @Test("조회에 실패하면 에러를 던진다")
+    func loadRegisteredNovelStatsFailureThrows() async {
+        let mock = MockNovelRepository()
+        mock.fetchRegisteredNovelStatsResult = .failure(TestError.networkFail)
+
+        let usecase = DefaultLoadRegisteredNovelStatsUsecase(novelRepository: mock)
+
+        await #expect(throws: TestError.networkFail) {
+            try await usecase.execute()
+        }
+    }
+}
+
+extension LoadRegisteredNovelStatsUsecaseTests {
+
+    private enum TestError: Error { case networkFail }
+
+    private func makeStats(
+        interest: Int = 10,
+        watching: Int = 20,
+        watched: Int = 30,
+        quit: Int = 5
+    ) -> RegisteredNovelStats {
+        RegisteredNovelStats(interest: interest, watching: watching, watched: watched, quit: quit)
+    }
+}

--- a/Projects/Domain/Profile/Demo/ContentView.swift
+++ b/Projects/Domain/Profile/Demo/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Projects/Domain/Profile/Demo/File.swift
+++ b/Projects/Domain/Profile/Demo/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  AppManifests
+//
+//  Created by YunhakLee on 2/22/26.
+//
+
+import Foundation

--- a/Projects/Domain/Profile/Demo/File.swift
+++ b/Projects/Domain/Profile/Demo/File.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  AppManifests
-//
-//  Created by YunhakLee on 2/22/26.
-//
-
-import Foundation

--- a/Projects/Domain/Profile/Demo/ProfileDomainDemoApp.swift
+++ b/Projects/Domain/Profile/Demo/ProfileDomainDemoApp.swift
@@ -1,0 +1,19 @@
+//
+//  ProfileDomainDemoApp.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+import SwiftUI
+
+@main
+struct ProfileDomainDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Projects/Domain/Profile/Project.swift
+++ b/Projects/Domain/Profile/Project.swift
@@ -1,0 +1,16 @@
+//
+//  Package.swift
+//  AppManifests
+//
+//  Created by YunhakLee on 10/21/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.createDomainModule(
+    name: ModuleType.Domain.profile.name,
+    targets: [.sources, .demo, .testing, .tests],
+    internalDependencies: [.Domain.BaseDomain]
+)

--- a/Projects/Domain/Profile/Sources/Base/AttractivePoint.swift
+++ b/Projects/Domain/Profile/Sources/Base/AttractivePoint.swift
@@ -1,0 +1,17 @@
+//
+//  AttractivePoint.swift
+//  NovelReviewDomain
+//
+//  Created by YunhakLee on 1/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public enum AttractivePoint: Equatable, CaseIterable {
+    case worldview
+    case material
+    case character
+    case relationship
+    case vibe
+}

--- a/Projects/Domain/Profile/Sources/Base/Keyword.swift
+++ b/Projects/Domain/Profile/Sources/Base/Keyword.swift
@@ -1,0 +1,20 @@
+//
+//  Keyword.swift
+//  NovelReviewDomain
+//
+//  Created by YunhakLee on 1/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+public struct Keyword: Equatable, Identifiable, Hashable {
+    public let id: KeywordID
+    public let name: String
+    
+    public init(id: KeywordID, name: String) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/Projects/Domain/Profile/Sources/Entity/AccountInfoDraft.swift
+++ b/Projects/Domain/Profile/Sources/Entity/AccountInfoDraft.swift
@@ -1,0 +1,33 @@
+//
+//  AccountInfoDraft.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+public struct AccountInfoDraft {
+    
+    public let email: String?
+    public private(set) var gender: Gender
+    public private(set) var birth: BirthYear
+    
+    // MARK: Init
+    
+    public init(email: String?, gender: Gender, birth: BirthYear) {
+        self.email = email
+        self.gender = gender
+        self.birth = birth
+    }
+    
+    // MARK: Mutating
+    
+    mutating func setGender(_ gender: Gender) {
+        self.gender = gender
+    }
+    
+    mutating func setBirth(_ birth: BirthYear) {
+        self.birth = birth
+    }
+}

--- a/Projects/Domain/Profile/Sources/Entity/AccountInfoDraft.swift
+++ b/Projects/Domain/Profile/Sources/Entity/AccountInfoDraft.swift
@@ -7,7 +7,7 @@
 //
 
 
-public struct AccountInfoDraft {
+public struct AccountInfoDraft: Equatable {
     
     public let email: String?
     public private(set) var gender: Gender

--- a/Projects/Domain/Profile/Sources/Entity/AssistantEntity/BirthYear.swift
+++ b/Projects/Domain/Profile/Sources/Entity/AssistantEntity/BirthYear.swift
@@ -1,0 +1,26 @@
+//
+//  BirthYear.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+public struct BirthYear: Equatable {
+    public let value: Int
+    
+    static public let minYear = 1900
+    static public let maxYear = 2024
+    
+    public init(_ value: Int) throws {
+        guard (Self.minYear...Self.maxYear).contains(value) else {
+            throw ValidationError.invalidRange
+        }
+        self.value = value
+    }
+    
+    public enum ValidationError: Error {
+        case invalidRange
+    }
+}

--- a/Projects/Domain/Profile/Sources/Entity/AssistantEntity/Gender.swift
+++ b/Projects/Domain/Profile/Sources/Entity/AssistantEntity/Gender.swift
@@ -1,0 +1,13 @@
+//
+//  Gender.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+public enum Gender: String {
+    case male
+    case female
+}

--- a/Projects/Domain/Profile/Sources/Entity/GenrePreference.swift
+++ b/Projects/Domain/Profile/Sources/Entity/GenrePreference.swift
@@ -1,0 +1,15 @@
+//
+//  GenrePreference.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct GenrePreference: Equatable {
+    public let name: String
+    public let image: URL?
+    public let count: Int
+}

--- a/Projects/Domain/Profile/Sources/Entity/NicknameDraft.swift
+++ b/Projects/Domain/Profile/Sources/Entity/NicknameDraft.swift
@@ -1,0 +1,104 @@
+//
+//  NicknameDraft.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct NicknameDraft {
+    
+    public private(set) var text: String = ""
+    
+    // MARK: INIT
+    
+    public init(_ initialName: String) {
+        lastNickname = initialName
+        text = initialName
+    }
+
+    // MARK: Policy
+    
+    private let lastNickname: String
+    private var duplicationCheckState: DuplicationCheckState = .notYet
+    private static let maxLength: Int = 10
+    private static let nicknamePattern = "^[a-zA-Z0-9가-힣]{2,10}$"
+ 
+    
+    public var validationState: ValidationState {
+        if text.isEmpty {
+            return .notStarted
+        }
+        
+        if containsWhitespace {
+            return .notAvailable(reason: .whiteSpaceIncluded)
+        }
+        
+        if !isChanged {
+            return .notAvailable(reason: .notChanged)
+        }
+        
+        if self.isValidPattern {
+            switch duplicationCheckState {
+            case .notYet: return .needDuplicatedCheck
+            case .duplicated: return .notAvailable(reason: .duplicated)
+            case .notDuplicated: return .available
+            }
+        } else {
+            return .notAvailable(reason: .invalidCharacterOrLimitExceeded)
+        }
+        
+    }
+    
+    private var isValidPattern: Bool {
+        text.range(of: Self.nicknamePattern, options: .regularExpression) != nil
+    }
+    
+    private var containsWhitespace: Bool {
+        text.rangeOfCharacter(from: .whitespacesAndNewlines) != nil
+    }
+    
+    private var isChanged: Bool {
+        text != lastNickname
+    }
+    
+    public enum ValidationState: Equatable {
+        case notStarted
+        case notAvailable(reason: NotAvailableReason)
+        case needDuplicatedCheck
+        case available
+    }
+
+    public enum NotAvailableReason: Equatable {
+        case whiteSpaceIncluded
+        case invalidCharacterOrLimitExceeded
+        case duplicated
+        case notChanged
+    }
+    
+    public enum DuplicationCheckState: Equatable {
+        case notYet
+        case duplicated
+        case notDuplicated
+    }
+    
+    // MARK: Mutating
+    
+    public mutating func setText(
+        _ newValue: String
+    ) {
+        let clippedText = String(newValue.prefix(Self.maxLength))
+        if clippedText != text { duplicationCheckState = .notYet }
+        self.text = clippedText
+    }
+    
+    public mutating func applyDuplicationCheckResult(
+        _ status: DuplicationCheckState,
+        checkedText: String
+    ) {
+        guard checkedText == text else { return }
+        duplicationCheckState = status
+    }
+}

--- a/Projects/Domain/Profile/Sources/Entity/NovelPreference.swift
+++ b/Projects/Domain/Profile/Sources/Entity/NovelPreference.swift
@@ -1,0 +1,14 @@
+//
+//  NovelPreference.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct NovelPreference {
+    public let attractivePoints: [AttractivePoint]
+    public let keywords: [Keyword : Int]
+}

--- a/Projects/Domain/Profile/Sources/Entity/Profile.swift
+++ b/Projects/Domain/Profile/Sources/Entity/Profile.swift
@@ -1,0 +1,18 @@
+//
+//  Profile.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+public struct Profile {
+    public let nickname: String
+    public let introduction: String
+    public let characterImage: URL?
+    public let isPublic: Bool
+    public let genrePreferences: [NovelGenre]
+}

--- a/Projects/Domain/Profile/Sources/Entity/ProfileCharacter.swift
+++ b/Projects/Domain/Profile/Sources/Entity/ProfileCharacter.swift
@@ -1,0 +1,22 @@
+//
+//  ProfileCharacter.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct ProfileCharacter {
+    
+    public let id: Int
+    
+    public let name: String
+    public let line: String
+    
+    public let representativeImage: URL?
+    public let thumbnailImage: URL?
+
+    public let isRepresentative: Bool
+}

--- a/Projects/Domain/Profile/Sources/Entity/ProfileDraft.swift
+++ b/Projects/Domain/Profile/Sources/Entity/ProfileDraft.swift
@@ -1,0 +1,110 @@
+//
+//  ProfileDraft.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct ProfileDraft {
+    public private(set) var characterID: Int
+    public private(set) var nickname: NicknameDraft
+    public private(set) var introduction: String
+    public private(set) var genrePreferences: [GenrePreference]
+    
+    private let initialCharacterID: Int
+    private let initialIntroduction: String
+    private let initialGenrePreferences: [GenrePreference]
+    
+    // MARK: Init
+    
+    public init(
+        characterID: Int,
+        nickname: String,
+        introduction: String,
+        genrePreferences: [GenrePreference]
+    ) {
+        self.characterID = characterID
+        self.nickname = NicknameDraft(nickname)
+        self.introduction = introduction
+        self.genrePreferences = genrePreferences
+        
+        self.initialCharacterID = characterID
+        self.initialIntroduction = introduction
+        self.initialGenrePreferences = genrePreferences
+    }
+    
+    // MARK: Change Detection
+
+    public var isCharacterChanged: Bool { characterID != initialCharacterID }
+    public var isNicknameChanged: Bool { nickname.validationState == .available }
+    public var isIntroductionChanged: Bool { introduction != initialIntroduction }
+    public var isGenrePreferencesChanged: Bool { genrePreferences != initialGenrePreferences }
+
+    // MARK: Policy
+
+    public var isSubmittable: Bool {
+        // 닉네임이 변경 중인데 유효하지 않은 경우 제출 불가
+        switch nickname.validationState {
+        case .needDuplicatedCheck:
+            return false
+        case .notAvailable(let reason) where reason != .notChanged:
+            return false
+        default:
+            break
+        }
+
+        return isNicknameChanged || isIntroductionChanged || isCharacterChanged || isGenrePreferencesChanged
+    }
+    
+    // MARK: Mutating
+    
+    // - character
+    
+    public mutating func setCharacter(_ newCharacterID: Int) {
+        self.characterID = newCharacterID
+    }
+    
+    // - nickname
+    
+    public mutating func updateNickname(_ newNickname: String) {
+        nickname.setText(newNickname)
+    }
+    
+    public mutating func applyNicknameDuplicationCheck(
+        _ state: NicknameDraft.DuplicationCheckState,
+        checkedText: String
+    ) {
+        nickname.applyDuplicationCheckResult(state, checkedText: checkedText)
+    }
+    
+    // - introduction
+    
+    private static let maxIntroductionLength: Int = 50
+    private static let maxLineCount: Int = 3
+    
+    public mutating func updateIntroduction(_ newValue: String) {
+        var lines = newValue.components(separatedBy: "\n")
+        
+        if lines.count > Self.maxLineCount {
+            lines = Array(lines.prefix(Self.maxLineCount))
+        }
+        
+        var text = lines.joined(separator: "\n")
+        text = String(text.prefix(Self.maxIntroductionLength))
+        
+        self.introduction = text
+    }
+    
+    // - genre preferences
+    
+    public mutating func addGenrePreference(_ genre: GenrePreference) {
+        genrePreferences.append(genre)
+    }
+    
+    public mutating func removeGenrePreference(_ genre: GenrePreference) {
+        genrePreferences.removeAll { $0 == genre }
+    }
+}

--- a/Projects/Domain/Profile/Sources/Entity/ProfileRegistration.swift
+++ b/Projects/Domain/Profile/Sources/Entity/ProfileRegistration.swift
@@ -1,0 +1,16 @@
+//
+//  ProfileRegistration.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import BaseDomain
+
+public struct ProfileRegistration {
+    public let nickname: String
+    public let gender: Gender
+    public let birthYear: BirthYear
+    public let genrePreferences: [NovelGenre]
+}

--- a/Projects/Domain/Profile/Sources/Entity/ProfileRegistration.swift
+++ b/Projects/Domain/Profile/Sources/Entity/ProfileRegistration.swift
@@ -8,7 +8,7 @@
 
 import BaseDomain
 
-public struct ProfileRegistration {
+public struct ProfileRegistration: Equatable {
     public let nickname: String
     public let gender: Gender
     public let birthYear: BirthYear

--- a/Projects/Domain/Profile/Sources/Entity/ProfileVisibility.swift
+++ b/Projects/Domain/Profile/Sources/Entity/ProfileVisibility.swift
@@ -1,0 +1,13 @@
+//
+//  ProfileVisibility.swift
+//  NotificationDomain
+//
+//  Created by YunhakLee on 2/11/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+public struct ProfileVisibility: Equatable {
+    public let isPublic: Bool
+    public init(isPublic: Bool) { self.isPublic = isPublic }
+}

--- a/Projects/Domain/Profile/Sources/File.swift
+++ b/Projects/Domain/Profile/Sources/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  AppManifests
+//
+//  Created by YunhakLee on 2/22/26.
+//
+
+import Foundation

--- a/Projects/Domain/Profile/Sources/File.swift
+++ b/Projects/Domain/Profile/Sources/File.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  AppManifests
-//
-//  Created by YunhakLee on 2/22/26.
-//
-
-import Foundation

--- a/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
+++ b/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
@@ -7,5 +7,8 @@
 //
 
 public protocol ProfileRepository {
+    
+    /// 받아온 성별, userID, 닉네임을 userDefaults에 저장
     func syncUserBasicInfo() async throws(RepositoryError)
+    func validateNickname(_ nickname: String) async throws(RepositoryError) -> Bool
 }

--- a/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
+++ b/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
@@ -12,4 +12,7 @@ public protocol ProfileRepository {
     func syncUserBasicInfo() async throws(RepositoryError)
     func validateNickname(_ nickname: String) async throws(RepositoryError) -> Bool
     func registerProfile(_ profile: ProfileRegistration) async throws(RepositoryError)
+    
+    func loadAccountInfoDraft() async throws(RepositoryError) -> AccountInfoDraft
+    func saveAccountInfo(_ info: AccountInfoDraft) async throws(RepositoryError)
 }

--- a/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
+++ b/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
@@ -11,4 +11,5 @@ public protocol ProfileRepository {
     /// 받아온 성별, userID, 닉네임을 userDefaults에 저장
     func syncUserBasicInfo() async throws(RepositoryError)
     func validateNickname(_ nickname: String) async throws(RepositoryError) -> Bool
+    func registerProfile(_ profile: ProfileRegistration) async throws(RepositoryError)
 }

--- a/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
+++ b/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
@@ -27,4 +27,10 @@ public protocol ProfileRepository {
     func fetchNovelPreferences(_ target: ProfileTarget) async throws(RepositoryError) -> NovelPreference
     
     func fetchProfileCharacters() async throws(RepositoryError) -> [ProfileCharacter]
+    
+    /// userDefaults에 저장된 닉네임, 프로필캐릭터ID를 가져온다.
+    /// 서버 api를 통해 소개글, 선택한 선호 장르를 가져온다.
+    func loadInitialProfile() async throws(RepositoryError) -> ProfileDraft
+    /// 수정된 닉네임, 프로필 캐릭터 ID를 userDefaults에 저장
+    func updateProfile(_ profile: ProfileDraft) async throws(RepositoryError)
 }

--- a/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
+++ b/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
@@ -15,4 +15,7 @@ public protocol ProfileRepository {
     
     func loadAccountInfoDraft() async throws(RepositoryError) -> AccountInfoDraft
     func saveAccountInfo(_ info: AccountInfoDraft) async throws(RepositoryError)
+    
+    func loadProfileVisibility() async throws(RepositoryError) -> ProfileVisibility
+    func updateProfileVisibility(_ visibility: ProfileVisibility) async throws(RepositoryError)
 }

--- a/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
+++ b/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
@@ -1,0 +1,11 @@
+//
+//  ProfileRepository.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+public protocol ProfileRepository {
+    func syncUserBasicInfo() async throws(RepositoryError)
+}

--- a/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
+++ b/Projects/Domain/Profile/Sources/Repository/ProfileRepository.swift
@@ -18,4 +18,13 @@ public protocol ProfileRepository {
     
     func loadProfileVisibility() async throws(RepositoryError) -> ProfileVisibility
     func updateProfileVisibility(_ visibility: ProfileVisibility) async throws(RepositoryError)
+    
+    /// target에 따라 로직을 분리한다.
+    ///  .me: 저장되어있는 userDefaults로부터 userID를 받아온다.
+    ///  .user: 다른 repository로부터 userID를 받아온다.
+    func fetchUserProfile(target: ProfileTarget) async throws(RepositoryError) -> Profile
+    func fetchGenrePreferences(_ target: ProfileTarget) async throws(RepositoryError) -> [GenrePreference]
+    func fetchNovelPreferences(_ target: ProfileTarget) async throws(RepositoryError) -> NovelPreference
+    
+    func fetchProfileCharacters() async throws(RepositoryError) -> [ProfileCharacter]
 }

--- a/Projects/Domain/Profile/Sources/Repository/ProfileTarget.swift
+++ b/Projects/Domain/Profile/Sources/Repository/ProfileTarget.swift
@@ -1,0 +1,15 @@
+//
+//  ProfileTarget.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+public enum ProfileTarget {
+    case me
+    case user(UserID)
+}

--- a/Projects/Domain/Profile/Sources/Repository/RepositoryError.swift
+++ b/Projects/Domain/Profile/Sources/Repository/RepositoryError.swift
@@ -1,0 +1,17 @@
+//
+//  RepositoryError.swift
+//  FeedDomain
+//
+//  Created by Seoyeon Choi on 2/8/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public enum RepositoryError: Error, Equatable {
+    case networkUnavailable
+    case authenticationRequired
+    case serverUnavailable
+    case notFound
+    case unknown
+}

--- a/Projects/Domain/Profile/Sources/UseCase/LoadAccountInfoDraftUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/LoadAccountInfoDraftUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  LoadAccountInfoDraftUseCase.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoadAccountInfoDraftUseCase {
+    func execute() async throws -> AccountInfoDraft
+}
+
+public class DefaultLoadAccountInfoDraftUseCase: LoadAccountInfoDraftUseCase {
+    let repository: ProfileRepository
+    
+    public init(repository: ProfileRepository) {
+        self.repository = repository
+    }
+    
+    public func execute() async throws -> AccountInfoDraft {
+        return try await repository.loadAccountInfoDraft()
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/LoadGenrePreferencesUsecase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/LoadGenrePreferencesUsecase.swift
@@ -1,0 +1,26 @@
+//
+//  LoadGenrePreferencesUsecase.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoadGenrePreferencesUsecase {
+    func execute(_ target: ProfileTarget) async throws -> [GenrePreference]
+}
+
+public final class DefaultLoadGenrePreferencesUsecase: LoadGenrePreferencesUsecase {
+    
+    private let profileRepository: ProfileRepository
+    
+    public init(profileRepository: ProfileRepository) {
+        self.profileRepository = profileRepository
+    }
+    
+    public func execute(_ target: ProfileTarget) async throws -> [GenrePreference] {
+        try await profileRepository.fetchGenrePreferences(target)
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/LoadInitialProfileUsecase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/LoadInitialProfileUsecase.swift
@@ -1,0 +1,26 @@
+//
+//  LoadInitialProfileUsecase.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoadInitialProfileUsecase {
+    func execute() async throws -> ProfileDraft
+}
+
+public final class DefaultLoadProfileDraftUsecase: LoadInitialProfileUsecase {
+
+    private let profileRepository: ProfileRepository
+
+    public init(profileRepository: ProfileRepository) {
+        self.profileRepository = profileRepository
+    }
+
+    public func execute() async throws -> ProfileDraft {
+        try await profileRepository.loadInitialProfile()
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/LoadNovelPreferencesUsecase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/LoadNovelPreferencesUsecase.swift
@@ -1,0 +1,26 @@
+//
+//  LoadNovelPreferencesUsecase.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoadNovelPreferencesUsecase {
+    func execute(_ target: ProfileTarget) async throws -> NovelPreference
+}
+
+public final class DefaultLoadNovelPreferencesUsecase: LoadNovelPreferencesUsecase {
+    
+    private let profileRepository: ProfileRepository
+    
+    public init(profileRepository: ProfileRepository) {
+        self.profileRepository = profileRepository
+    }
+    
+    public func execute(_ target: ProfileTarget) async throws -> NovelPreference {
+        try await profileRepository.fetchNovelPreferences(target)
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/LoadProfileCharacterUsecase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/LoadProfileCharacterUsecase.swift
@@ -1,0 +1,26 @@
+//
+//  LoadProfileCharacterUsecase.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoadProfileCharacterUsecase {
+    func execute() async throws -> [ProfileCharacter]
+}
+
+public final class DefaultLoadProfileCharacterUsecase: LoadProfileCharacterUsecase {
+    
+    private let profileRepository: ProfileRepository
+    
+    public init(profileRepository: ProfileRepository) {
+        self.profileRepository = profileRepository
+    }
+    
+    public func execute() async throws -> [ProfileCharacter] {
+        try await profileRepository.fetchProfileCharacters()
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/LoadProfileUsecase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/LoadProfileUsecase.swift
@@ -1,0 +1,27 @@
+//
+//  LoadProfileUsecase.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import BaseDomain
+
+public protocol LoadProfileUsecase {
+    func execute(target: ProfileTarget) async throws -> Profile
+}
+
+public final class DefaultLoadProfileUsecase: LoadProfileUsecase {
+    
+    private let profileRepository: ProfileRepository
+    
+    public init(profileRepository: ProfileRepository) {
+        self.profileRepository = profileRepository
+    }
+    
+    public func execute(target: ProfileTarget) async throws -> Profile {
+        try await profileRepository.fetchUserProfile(target: target)
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/LoadProfileVisibilityUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/LoadProfileVisibilityUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  LoadProfileVisibilityUseCase.swift
+//  NotificationDomain
+//
+//  Created by YunhakLee on 2/11/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+public protocol LoadProfileVisibilityUseCase {
+    func execute() async throws -> ProfileVisibility
+}
+
+public final class DefaultLoadProfileVisibilityUseCase: LoadProfileVisibilityUseCase {
+    private let repository: ProfileRepository
+
+    public init(repository: ProfileRepository) {
+        self.repository = repository
+    }
+
+    public func execute() async throws -> ProfileVisibility {
+        try await repository.loadProfileVisibility()
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/RegisterProfileUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/RegisterProfileUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  RegisterProfileUseCase.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol RegisterProfileUseCase {
+    func excute(_ profile: ProfileRegistration) async throws
+}
+
+public class DefaultRegisterProfileUseCase: RegisterProfileUseCase {
+    let repository: ProfileRepository
+    
+    public init(repository: ProfileRepository) {
+        self.repository = repository
+    }
+    
+    public func excute(_ profile: ProfileRegistration) async throws {
+        _ = try await repository.registerProfile(profile)
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/RegisterProfileUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/RegisterProfileUseCase.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol RegisterProfileUseCase {
-    func excute(_ profile: ProfileRegistration) async throws
+    func execute(_ profile: ProfileRegistration) async throws
 }
 
 public class DefaultRegisterProfileUseCase: RegisterProfileUseCase {
@@ -19,7 +19,7 @@ public class DefaultRegisterProfileUseCase: RegisterProfileUseCase {
         self.repository = repository
     }
     
-    public func excute(_ profile: ProfileRegistration) async throws {
+    public func execute(_ profile: ProfileRegistration) async throws {
         _ = try await repository.registerProfile(profile)
     }
 }

--- a/Projects/Domain/Profile/Sources/UseCase/SaveAccountInfoDraftUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/SaveAccountInfoDraftUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  SaveAccountInfoDraftUseCase.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol SaveAccountInfoDraftUseCase {
+    func execute(_ info: AccountInfoDraft) async throws
+}
+
+public class DefaultSaveAccountInfoDraftUseCase: SaveAccountInfoDraftUseCase {
+    let repository: ProfileRepository
+    
+    public init(repository: ProfileRepository) {
+        self.repository = repository
+    }
+    
+    public func execute(_ info: AccountInfoDraft) async throws {
+        return try await repository.saveAccountInfo(info)
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/SyncUserBasicInfoUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/SyncUserBasicInfoUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  SyncUserBasicInfoUseCase.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol SyncUserBasicInfoUseCase {
+    func excute() async throws
+}
+
+
+public class DefaultSyncUserBasicInfoUseCase: SyncUserBasicInfoUseCase {
+    let repository: ProfileRepository
+    
+    public init(repository: ProfileRepository) {
+        self.repository = repository
+    }
+    
+    public func excute() async throws {
+        _ = try await repository.fetchUserBasicInfo()
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/SyncUserBasicInfoUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/SyncUserBasicInfoUseCase.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol SyncUserBasicInfoUseCase {
-    func excute() async throws
+    func execute() async throws
 }
 
 public class DefaultSyncUserBasicInfoUseCase: SyncUserBasicInfoUseCase {
@@ -19,7 +19,7 @@ public class DefaultSyncUserBasicInfoUseCase: SyncUserBasicInfoUseCase {
         self.repository = repository
     }
     
-    public func excute() async throws {
+    public func execute() async throws {
         _ = try await repository.syncUserBasicInfo()
     }
 }

--- a/Projects/Domain/Profile/Sources/UseCase/UpdateProfileUsecase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/UpdateProfileUsecase.swift
@@ -1,0 +1,26 @@
+//
+//  UpdateProfileUsecase.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol UpdateProfileUsecase {
+    func execute(_ draft: ProfileDraft) async throws
+}
+
+public final class DefaultUpdateProfileUsecase: UpdateProfileUsecase {
+
+    private let profileRepository: ProfileRepository
+
+    public init(profileRepository: ProfileRepository) {
+        self.profileRepository = profileRepository
+    }
+
+    public func execute(_ draft: ProfileDraft) async throws {
+        try await profileRepository.updateProfile(draft)
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/UpdateProfileVisibilityUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/UpdateProfileVisibilityUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  UpdateProfileVisibilityUseCase.swift
+//  NotificationDomain
+//
+//  Created by YunhakLee on 2/11/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+public protocol UpdateProfileVisibilityUseCase {
+    func execute(_ visibility: ProfileVisibility) async throws
+}
+
+public final class DefaultUpdateProfileVisibilityUseCase: UpdateProfileVisibilityUseCase {
+    private let repository: ProfileRepository
+
+    public init(repository: ProfileRepository) {
+        self.repository = repository
+    }
+
+    public func execute(_ visibility: ProfileVisibility) async throws {
+        try await repository.updateProfileVisibility(visibility)
+    }
+}

--- a/Projects/Domain/Profile/Sources/UseCase/ValidateNicknameUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/ValidateNicknameUseCase.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-public protocol SyncUserBasicInfoUseCase {
-    func excute() async throws
+public protocol ValidateNicknameUseCase {
+    func excute(_ nickname: String) async throws -> Bool
 }
 
-public class DefaultSyncUserBasicInfoUseCase: SyncUserBasicInfoUseCase {
+public class DefaultValidateNicknameUseCase: ValidateNicknameUseCase {
     let repository: ProfileRepository
     
     public init(repository: ProfileRepository) {
         self.repository = repository
     }
     
-    public func excute() async throws {
-        _ = try await repository.syncUserBasicInfo()
+    public func excute(_ nickname: String) async throws -> Bool {
+        return try await repository.validateNickname(nickname)
     }
 }

--- a/Projects/Domain/Profile/Sources/UseCase/ValidateNicknameUseCase.swift
+++ b/Projects/Domain/Profile/Sources/UseCase/ValidateNicknameUseCase.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol ValidateNicknameUseCase {
-    func excute(_ nickname: String) async throws -> Bool
+    func execute(_ nickname: String) async throws -> Bool
 }
 
 public class DefaultValidateNicknameUseCase: ValidateNicknameUseCase {
@@ -19,7 +19,7 @@ public class DefaultValidateNicknameUseCase: ValidateNicknameUseCase {
         self.repository = repository
     }
     
-    public func excute(_ nickname: String) async throws -> Bool {
+    public func execute(_ nickname: String) async throws -> Bool {
         return try await repository.validateNickname(nickname)
     }
 }

--- a/Projects/Domain/Profile/Testing/File.swift
+++ b/Projects/Domain/Profile/Testing/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  AppManifests
+//
+//  Created by YunhakLee on 2/22/26.
+//
+
+import Foundation

--- a/Projects/Domain/Profile/Testing/Mock/MockProfileRepository.swift
+++ b/Projects/Domain/Profile/Testing/Mock/MockProfileRepository.swift
@@ -38,6 +38,22 @@ final class MockProfileRepository: ProfileRepository {
     private(set) var updateProfileVisibilityCallCount = 0
     private(set) var updatedVisibilities: [ProfileVisibility] = []
 
+    private(set) var fetchUserProfileCallCount = 0
+    private(set) var fetchedUserProfileTargets: [ProfileTarget] = []
+
+    private(set) var fetchGenrePreferencesCallCount = 0
+    private(set) var fetchedGenrePreferenceTargets: [ProfileTarget] = []
+
+    private(set) var fetchNovelPreferencesCallCount = 0
+    private(set) var fetchedNovelPreferenceTargets: [ProfileTarget] = []
+
+    private(set) var fetchProfileCharactersCallCount = 0
+
+    private(set) var loadInitialProfileCallCount = 0
+
+    private(set) var updateProfileCallCount = 0
+    private(set) var updatedDrafts: [ProfileDraft] = []
+
     // MARK: - Results (set by tests)
 
     var syncUserBasicInfoResult: Result<Void, RepositoryError> = .success(())
@@ -49,6 +65,14 @@ final class MockProfileRepository: ProfileRepository {
 
     var loadProfileVisibilityResult: Result<ProfileVisibility, RepositoryError>!
     var updateProfileVisibilityResult: Result<Void, RepositoryError> = .success(())
+
+    var fetchUserProfileResult: Result<Profile, RepositoryError>!
+    var fetchGenrePreferencesResult: Result<[GenrePreference], RepositoryError>!
+    var fetchNovelPreferencesResult: Result<NovelPreference, RepositoryError>!
+    var fetchProfileCharactersResult: Result<[ProfileCharacter], RepositoryError>!
+
+    var loadInitialProfileResult: Result<ProfileDraft, RepositoryError>!
+    var updateProfileResult: Result<Void, RepositoryError> = .success(())
 
     // MARK: - ProfileRepository
 
@@ -129,6 +153,59 @@ final class MockProfileRepository: ProfileRepository {
             return
         case .failure(let e):
             throw e
+        }
+    }
+
+    func fetchUserProfile(target: ProfileTarget) async throws(RepositoryError) -> Profile {
+        fetchUserProfileCallCount += 1
+        fetchedUserProfileTargets.append(target)
+        switch fetchUserProfileResult! {
+        case .success(let value): return value
+        case .failure(let e): throw e
+        }
+    }
+
+    func fetchGenrePreferences(_ target: ProfileTarget) async throws(RepositoryError) -> [GenrePreference] {
+        fetchGenrePreferencesCallCount += 1
+        fetchedGenrePreferenceTargets.append(target)
+        switch fetchGenrePreferencesResult! {
+        case .success(let value): return value
+        case .failure(let e): throw e
+        }
+    }
+
+    func fetchNovelPreferences(_ target: ProfileTarget) async throws(RepositoryError) -> NovelPreference {
+        fetchNovelPreferencesCallCount += 1
+        fetchedNovelPreferenceTargets.append(target)
+        switch fetchNovelPreferencesResult! {
+        case .success(let value): return value
+        case .failure(let e): throw e
+        }
+    }
+
+    func fetchProfileCharacters() async throws(RepositoryError) -> [ProfileCharacter] {
+        fetchProfileCharactersCallCount += 1
+        switch fetchProfileCharactersResult! {
+        case .success(let value): return value
+        case .failure(let e): throw e
+        }
+    }
+
+    func loadInitialProfile() async throws(RepositoryError) -> ProfileDraft {
+        loadInitialProfileCallCount += 1
+        switch loadInitialProfileResult! {
+        case .success(let value): return value
+        case .failure(let e): throw e
+        }
+    }
+
+    func updateProfile(_ profile: ProfileDraft) async throws(RepositoryError) {
+        updateProfileCallCount += 1
+        updatedDrafts.append(profile)
+
+        switch updateProfileResult {
+        case .success: return
+        case .failure(let e): throw e
         }
     }
 }

--- a/Projects/Domain/Profile/Testing/Mock/MockProfileRepository.swift
+++ b/Projects/Domain/Profile/Testing/Mock/MockProfileRepository.swift
@@ -1,0 +1,134 @@
+//
+//  MockProfileRepository.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  MockProfileRepository.swift
+//  ProfileDomainTests
+//
+
+import Foundation
+import BaseDomain
+@testable import ProfileDomain
+
+final class MockProfileRepository: ProfileRepository {
+
+    // MARK: - Call tracking
+
+    private(set) var syncUserBasicInfoCallCount = 0
+
+    private(set) var validateNicknameCallCount = 0
+    private(set) var validatedNicknames: [String] = []
+
+    private(set) var registerProfileCallCount = 0
+    private(set) var registeredProfiles: [ProfileRegistration] = []
+
+    private(set) var loadAccountInfoDraftCallCount = 0
+
+    private(set) var saveAccountInfoCallCount = 0
+    private(set) var savedAccountInfos: [AccountInfoDraft] = []
+
+    private(set) var loadProfileVisibilityCallCount = 0
+
+    private(set) var updateProfileVisibilityCallCount = 0
+    private(set) var updatedVisibilities: [ProfileVisibility] = []
+
+    // MARK: - Results (set by tests)
+
+    var syncUserBasicInfoResult: Result<Void, RepositoryError> = .success(())
+    var validateNicknameResult: Result<Bool, RepositoryError> = .success(false)
+    var registerProfileResult: Result<Void, RepositoryError> = .success(())
+
+    var loadAccountInfoDraftResult: Result<AccountInfoDraft, RepositoryError>!
+    var saveAccountInfoResult: Result<Void, RepositoryError> = .success(())
+
+    var loadProfileVisibilityResult: Result<ProfileVisibility, RepositoryError>!
+    var updateProfileVisibilityResult: Result<Void, RepositoryError> = .success(())
+
+    // MARK: - ProfileRepository
+
+    func syncUserBasicInfo() async throws(RepositoryError) {
+        syncUserBasicInfoCallCount += 1
+        switch syncUserBasicInfoResult {
+        case .success:
+            return
+        case .failure(let e):
+            throw e
+        }
+    }
+
+    func validateNickname(_ nickname: String) async throws(RepositoryError) -> Bool {
+        validateNicknameCallCount += 1
+        validatedNicknames.append(nickname)
+
+        switch validateNicknameResult {
+        case .success(let value):
+            return value
+        case .failure(let e):
+            throw e
+        }
+    }
+
+    func registerProfile(_ profile: ProfileRegistration) async throws(RepositoryError) {
+        registerProfileCallCount += 1
+        registeredProfiles.append(profile)
+
+        switch registerProfileResult {
+        case .success:
+            return
+        case .failure(let e):
+            throw e
+        }
+    }
+
+    func loadAccountInfoDraft() async throws(RepositoryError) -> AccountInfoDraft {
+        loadAccountInfoDraftCallCount += 1
+
+        switch loadAccountInfoDraftResult! {
+        case .success(let draft):
+            return draft
+        case .failure(let e):
+            throw e
+        }
+    }
+
+    func saveAccountInfo(_ info: AccountInfoDraft) async throws(RepositoryError) {
+        saveAccountInfoCallCount += 1
+        savedAccountInfos.append(info)
+
+        switch saveAccountInfoResult {
+        case .success:
+            return
+        case .failure(let e):
+            throw e
+        }
+    }
+
+    func loadProfileVisibility() async throws(RepositoryError) -> ProfileVisibility {
+        loadProfileVisibilityCallCount += 1
+
+        switch loadProfileVisibilityResult! {
+        case .success(let v):
+            return v
+        case .failure(let e):
+            throw e
+        }
+    }
+
+    func updateProfileVisibility(_ visibility: ProfileVisibility) async throws(RepositoryError) {
+        updateProfileVisibilityCallCount += 1
+        updatedVisibilities.append(visibility)
+
+        switch updateProfileVisibilityResult {
+        case .success:
+            return
+        case .failure(let e):
+            throw e
+        }
+    }
+}

--- a/Projects/Domain/Profile/Tests/Entity/AccountInfoDraftTests.swift
+++ b/Projects/Domain/Profile/Tests/Entity/AccountInfoDraftTests.swift
@@ -1,0 +1,66 @@
+//
+//  AccountInfoDraftTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  AccountInfoDraftTests.swift
+//  ProfileDomainTests
+//
+
+import Testing
+@testable import ProfileDomain
+
+@Suite("AccountInfoDraft")
+struct AccountInfoDraftTests {
+    private func makeBirthYear(_ year: Int) -> BirthYear {
+        try! BirthYear(year)
+    }
+    
+    private func makeDraft(
+        email: String? = "test@email.com",
+        gender: Gender = .male,
+        birth: BirthYear = try! BirthYear(2002)
+    ) -> AccountInfoDraft {
+        AccountInfoDraft(
+            email: email,
+            gender: gender,
+            birth: birth
+        )
+    }
+
+    @Test("초기화 시 전달한 값으로 생성된다")
+    func initializesWithGivenValues() {
+        let draft = makeDraft(
+            email: "hello@test.com",
+            gender: .female,
+            birth: makeBirthYear(1999)
+        )
+
+        #expect(draft.email == "hello@test.com")
+        #expect(draft.gender == .female)
+        #expect(draft.birth == makeBirthYear(1999))
+    }
+
+    @Test("성별을 변경할 수 있다")
+    func changesGender() {
+        var draft = makeDraft(gender: .male)
+
+        draft.setGender(.female)
+
+        #expect(draft.gender == .female)
+    }
+
+    @Test("출생년도를 변경할 수 있다")
+    func changesBirthYear() {
+        var draft = makeDraft(birth: makeBirthYear(2000))
+
+        draft.setBirth(makeBirthYear(1995))
+
+        #expect(draft.birth == makeBirthYear(1995))
+    }
+}

--- a/Projects/Domain/Profile/Tests/Entity/NicknameDraftTests.swift
+++ b/Projects/Domain/Profile/Tests/Entity/NicknameDraftTests.swift
@@ -1,0 +1,138 @@
+//
+//  NicknameDraftTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/24/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+import Testing
+@testable import ProfileDomain
+
+@Suite("NicknameDraft")
+struct NicknameDraftTests {
+
+    // MARK: - Helpers
+
+    private func makeDraft(initial: String = "기존닉네임") -> NicknameDraft {
+        NicknameDraft(initial)
+    }
+
+    // MARK: - Init
+
+    @Test("초기화 시 text는 초기 닉네임이다")
+    func initSetsTextToInitialName() {
+        let draft = NicknameDraft("윤학")
+        #expect(draft.text == "윤학")
+    }
+    
+    // MARK: - Length clipping
+
+    @Test("닉네임은 최대 10자까지만 입력된다")
+    func clipsToMaxLength10() {
+        var draft = makeDraft()
+        draft.setText("일이삼사오육칠팔구십일") // 11 chars
+        #expect(draft.text == "일이삼사오육칠팔구십")
+    }
+
+    // MARK: - notAvailable
+
+    @Test("닉네임이 비어있으면 어떠한 검증도 불가하므로 notStarted 상태다")
+    func emptyTextIsNotStarted() {
+        let draft = makeDraft(initial: "")
+        #expect(draft.validationState == .notStarted)
+    }
+    
+    @Test("초기 닉네임과 동일하면 notAvailable(notChanged) 상태다")
+    func initialSameAsLastNicknameIsNotChanged() {
+        let draft = makeDraft(initial: "윤학")
+        #expect(draft.validationState == .notAvailable(reason: .notChanged))
+    }
+    
+    @Test("초기 닉네임으로 되돌리면 notAvailable(notChanged) 상태다")
+    func revertingToLastNicknameIsNotChanged() {
+        var draft = makeDraft(initial: "윤학")
+        draft.setText("abcd")
+        #expect(draft.validationState == .needDuplicatedCheck)
+
+        draft.setText("윤학")
+        #expect(draft.validationState == .notAvailable(reason: .notChanged))
+    }
+
+    @Test("공백 또는 줄바꿈/탭이 포함되면 notAvailable(whiteSpaceIncluded) 상태다")
+    func whitespaceIncludedIsNotAvailable() {
+        var draft = makeDraft(initial: "윤학")
+
+        draft.setText("ab cd")
+        #expect(draft.validationState == .notAvailable(reason: .whiteSpaceIncluded))
+
+        draft.setText("ab\tcd")
+        #expect(draft.validationState == .notAvailable(reason: .whiteSpaceIncluded))
+
+        draft.setText("ab\ncd")
+        #expect(draft.validationState == .notAvailable(reason: .whiteSpaceIncluded))
+    }
+
+    @Test("정규식 조건을 만족하지 않으면 notAvailable(invalidCharacterOrLimitExceeded) 상태다")
+    func invalidPatternIsNotAvailable() {
+        var draft = makeDraft(initial: "윤학")
+        draft.setText("ab!cd") // '!' not allowed
+        #expect(draft.validationState == .notAvailable(reason: .invalidCharacterOrLimitExceeded))
+    }
+
+    // MARK: - Duplication check flow
+
+    @Test("유효한 닉네임을 입력했지만 중복 검사 전이면 needDuplicatedCheck 상태다")
+    func validButNotCheckedIsNeedDuplicatedCheck() {
+        var draft = makeDraft(initial: "윤학")
+        draft.setText("abcd") // valid, changed
+        #expect(draft.validationState == .needDuplicatedCheck)
+    }
+
+    @Test("중복 검사 결과가 duplicated면 notAvailable(duplicated) 상태다")
+    func duplicatedResultMakesNotAvailableDuplicated() {
+        var draft = makeDraft(initial: "윤학")
+        draft.setText("abcd")
+
+        draft.applyDuplicationCheckResult(.duplicated, checkedText: "abcd")
+        #expect(draft.validationState == .notAvailable(reason: .duplicated))
+    }
+
+    @Test("중복 검사 결과가 notDuplicated면 available 상태다")
+    func notDuplicatedResultMakesAvailable() {
+        var draft = makeDraft(initial: "윤학")
+        draft.setText("abcd")
+
+        draft.applyDuplicationCheckResult(.notDuplicated, checkedText: "abcd")
+        #expect(draft.validationState == .available)
+    }
+
+    @Test("중복 검사 결과는 검사를 실행한 checkedText가 현재 text와 다르면 무시된다(비동기 동작 대비)")
+    func ignoresDuplicationResultWhenCheckedTextMismatch() {
+        var draft = makeDraft(initial: "윤학")
+        draft.setText("abcd")
+
+        // user typed again before response arrives
+        draft.setText("abcde")
+
+        // late response for old text
+        draft.applyDuplicationCheckResult(.notDuplicated, checkedText: "abcd")
+
+        // still need check for current text
+        #expect(draft.validationState == .needDuplicatedCheck)
+    }
+
+    @Test("텍스트가 변경되면 중복 검사 상태는 notYet으로 리셋된다")
+    func changingTextResetsDuplicationState() {
+        var draft = makeDraft(initial: "윤학")
+        draft.setText("abcd")
+        draft.applyDuplicationCheckResult(.notDuplicated, checkedText: "abcd")
+        #expect(draft.validationState == .available)
+
+        // change -> should require check again
+        // isValidPattern && notYet -> needDuplicatedCheck
+        draft.setText("abcde")
+        #expect(draft.validationState == .needDuplicatedCheck)
+    }
+}

--- a/Projects/Domain/Profile/Tests/Entity/ProfileDraftTests.swift
+++ b/Projects/Domain/Profile/Tests/Entity/ProfileDraftTests.swift
@@ -1,0 +1,302 @@
+//
+//  ProfileDraftTests.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import ProfileDomain
+
+@Suite("ProfileDraft")
+struct ProfileDraftTests {
+
+    // MARK: - Init
+
+    @Test("초기화 시 전달한 값으로 생성된다")
+    func initializesWithGivenValues() {
+        let genre = makeGenre()
+        let draft = makeDraft(characterID: 3,
+                              nickname: "서연",
+                              introduction: "반가워요",
+                              genrePreferences: [genre])
+
+        #expect(draft.characterID == 3)
+        #expect(draft.nickname.text == "서연")
+        #expect(draft.introduction == "반가워요")
+        #expect(draft.genrePreferences == [genre])
+    }
+
+    // MARK: - Change Detection
+
+    @Test("초기화 직후에는 변경된 항목이 없다")
+    func noChangesRightAfterInit() {
+        let draft = makeDraft()
+
+        #expect(draft.isCharacterChanged == false)
+        #expect(draft.isNicknameChanged == false)
+        #expect(draft.isIntroductionChanged == false)
+        #expect(draft.isGenrePreferencesChanged == false)
+    }
+
+    @Test("다른 캐릭터로 변경하면 isCharacterChanged가 true다")
+    func isCharacterChangedWhenDifferentID() {
+        var draft = makeDraft(characterID: 1)
+        draft.setCharacter(2)
+
+        #expect(draft.isCharacterChanged == true)
+    }
+
+    @Test("동일한 캐릭터로 설정하면 isCharacterChanged가 false다")
+    func isCharacterNotChangedWhenSameID() {
+        var draft = makeDraft(characterID: 1)
+        draft.setCharacter(1)
+
+        #expect(draft.isCharacterChanged == false)
+    }
+
+    @Test("닉네임이 변경되고 중복확인까지 통과하면 isNicknameChanged가 true다")
+    func isNicknameChangedWhenAvailable() {
+        let draft = makeDraftWithAvailableNickname()
+
+        #expect(draft.isNicknameChanged == true)
+    }
+
+    @Test("닉네임이 변경됐지만 중복확인 전이면 isNicknameChanged가 false다")
+    func isNicknameNotChangedBeforeDuplicationCheck() {
+        var draft = makeDraft(nickname: "서연")
+        draft.updateNickname("newNick")
+
+        #expect(draft.isNicknameChanged == false)
+    }
+
+    @Test("소개글을 다른 값으로 변경하면 isIntroductionChanged가 true다")
+    func isIntroductionChangedWhenDifferent() {
+        var draft = makeDraft(introduction: "안녕하세요")
+        draft.updateIntroduction("반가워요")
+
+        #expect(draft.isIntroductionChanged == true)
+    }
+
+    @Test("소개글을 초기값으로 되돌리면 isIntroductionChanged가 false다")
+    func isIntroductionNotChangedWhenReverted() {
+        var draft = makeDraft(introduction: "안녕하세요")
+        draft.updateIntroduction("반가워요")
+        draft.updateIntroduction("안녕하세요")
+
+        #expect(draft.isIntroductionChanged == false)
+    }
+
+    @Test("장르를 추가하면 isGenrePreferencesChanged가 true다")
+    func isGenreChangedAfterAdd() {
+        var draft = makeDraft(genrePreferences: [])
+        draft.addGenrePreference(makeGenre())
+
+        #expect(draft.isGenrePreferencesChanged == true)
+    }
+
+    @Test("장르를 추가했다가 삭제해 초기 상태로 돌아오면 isGenrePreferencesChanged가 false다")
+    func isGenreNotChangedWhenReverted() {
+        let genre = makeGenre()
+        var draft = makeDraft(genrePreferences: [genre])
+        draft.removeGenrePreference(genre)
+        draft.addGenrePreference(genre)
+
+        #expect(draft.isGenrePreferencesChanged == false)
+    }
+
+    // MARK: - isSubmittable
+
+    @Test("아무것도 변경되지 않으면 isSubmittable이 false다")
+    func notSubmittableWhenNothingChanged() {
+        let draft = makeDraft()
+
+        #expect(draft.isSubmittable == false)
+    }
+
+    @Test("캐릭터만 변경해도 isSubmittable이 true다")
+    func submittableWhenOnlyCharacterChanged() {
+        var draft = makeDraft(characterID: 1)
+        draft.setCharacter(2)
+
+        #expect(draft.isSubmittable == true)
+    }
+
+    @Test("닉네임만 변경하고 중복확인까지 통과하면 isSubmittable이 true다")
+    func submittableWhenNicknameAvailable() {
+        let draft = makeDraftWithAvailableNickname()
+
+        #expect(draft.isSubmittable == true)
+    }
+
+    @Test("소개글만 변경해도 isSubmittable이 true다")
+    func submittableWhenOnlyIntroductionChanged() {
+        var draft = makeDraft(introduction: "안녕하세요")
+        draft.updateIntroduction("반가워요")
+
+        #expect(draft.isSubmittable == true)
+    }
+
+    @Test("장르만 변경해도 isSubmittable이 true다")
+    func submittableWhenOnlyGenreChanged() {
+        var draft = makeDraft(genrePreferences: [])
+        draft.addGenrePreference(makeGenre())
+
+        #expect(draft.isSubmittable == true)
+    }
+
+    @Test("닉네임이 중복확인 필요 상태면 다른 필드가 변경되어도 isSubmittable이 false다")
+    func notSubmittableWhenNeedDuplicatedCheck() {
+        var draft = makeDraft(nickname: "서연")
+        draft.updateNickname("newNick") // needDuplicatedCheck
+        draft.setCharacter(2)
+
+        #expect(draft.isSubmittable == false)
+    }
+
+    @Test("닉네임이 중복이면 다른 필드가 변경되어도 isSubmittable이 false다")
+    func notSubmittableWhenNicknameDuplicated() {
+        var draft = makeDraft(nickname: "서연")
+        draft.updateNickname("newNick")
+        draft.applyNicknameDuplicationCheck(.duplicated, checkedText: "newNick")
+        draft.setCharacter(2)
+
+        #expect(draft.isSubmittable == false)
+    }
+
+    @Test("닉네임에 공백이 포함되면 다른 필드가 변경되어도 isSubmittable이 false다")
+    func notSubmittableWhenNicknameHasWhitespace() {
+        var draft = makeDraft(nickname: "서연")
+        draft.updateNickname("new Nick")
+        draft.setCharacter(2)
+
+        #expect(draft.isSubmittable == false)
+    }
+
+    @Test("닉네임이 유효하지 않은 패턴이면 다른 필드가 변경되어도 isSubmittable이 false다")
+    func notSubmittableWhenNicknameInvalidPattern() {
+        var draft = makeDraft(nickname: "서연")
+        draft.updateNickname("ab!cd")
+        draft.setCharacter(2)
+
+        #expect(draft.isSubmittable == false)
+    }
+
+    // MARK: - update Introduction
+
+    @Test("소개글 50자 이하면 그대로 저장된다")
+    func keepsIntroductionUnder50Characters() {
+        var draft = makeDraft()
+        let text = String(repeating: "가", count: 50)
+        draft.updateIntroduction(text)
+
+        #expect(draft.introduction.count == 50)
+    }
+
+    @Test("소개글이 50자를 초과하면 50자까지만 저장된다")
+    func clipsIntroductionTo50Characters() {
+        var draft = makeDraft()
+        let text = String(repeating: "가", count: 60)
+        draft.updateIntroduction(text)
+
+        #expect(draft.introduction.count == 50)
+    }
+
+    @Test("소개글 3줄 이하면 그대로 저장된다")
+    func keeps3LinesExactly() {
+        var draft = makeDraft()
+        draft.updateIntroduction("1줄\n2줄\n3줄")
+
+        #expect(draft.introduction == "1줄\n2줄\n3줄")
+    }
+
+    @Test("소개글이 3줄을 초과하면 3줄까지만 저장된다")
+    func clipsIntroductionTo3Lines() {
+        var draft = makeDraft()
+        draft.updateIntroduction("1줄\n2줄\n3줄\n4줄")
+
+        #expect(draft.introduction == "1줄\n2줄\n3줄")
+    }
+
+    @Test("소개글에 앞뒤 공백이 포함되어도 그대로 저장된다")
+    func allowsWhitespaceInIntroduction() {
+        var draft = makeDraft()
+        draft.updateIntroduction("  공백 포함  ")
+
+        #expect(draft.introduction == "  공백 포함  ")
+    }
+
+    @Test("소개글을 빈 문자열로 업데이트할 수 있다")
+    func allowsEmptyIntroduction() {
+        var draft = makeDraft(introduction: "안녕하세요")
+        draft.updateIntroduction("")
+
+        #expect(draft.introduction == "")
+    }
+
+    // MARK: - Genre Preference
+
+    @Test("장르를 추가할 수 있다")
+    func addsGenrePreference() {
+        var draft = makeDraft()
+        let genre = makeGenre(name: "로맨스")
+        draft.addGenrePreference(genre)
+
+        #expect(draft.genrePreferences.contains(genre))
+    }
+
+    @Test("장르를 삭제할 수 있다")
+    func removesGenrePreference() {
+        let genre = makeGenre(name: "로맨스")
+        var draft = makeDraft(genrePreferences: [genre])
+        draft.removeGenrePreference(genre)
+
+        #expect(draft.genrePreferences.isEmpty)
+    }
+
+    @Test("존재하지 않는 장르를 삭제해도 기존 장르는 유지된다")
+    func removingNonExistentGenreKeepsOthers() {
+        let romance = makeGenre(name: "로맨스")
+        let fantasy = makeGenre(name: "판타지")
+        var draft = makeDraft(genrePreferences: [romance])
+        draft.removeGenrePreference(fantasy)
+
+        #expect(draft.genrePreferences == [romance])
+    }
+}
+
+extension ProfileDraftTests {
+    
+    // MARK: - Helpers
+
+    private func makeDraft(
+        characterID: Int = 1,
+        nickname: String = "서연",
+        introduction: String = "안녕하세요",
+        genrePreferences: [GenrePreference] = []
+    ) -> ProfileDraft {
+        ProfileDraft(
+            characterID: characterID,
+            nickname: nickname,
+            introduction: introduction,
+            genrePreferences: genrePreferences
+        )
+    }
+
+    private func makeGenre(name: String = "로맨스") -> GenrePreference {
+        GenrePreference(name: name, image: nil, count: 0)
+    }
+
+    // 닉네임 변경 + 중복확인까지 통과한 draft
+    private func makeDraftWithAvailableNickname(
+        initial: String = "서연",
+        new: String = "newNick"
+    ) -> ProfileDraft {
+        var draft = makeDraft(nickname: initial)
+        draft.updateNickname(new)
+        draft.applyNicknameDuplicationCheck(.notDuplicated, checkedText: new)
+        return draft
+    }
+
+}

--- a/Projects/Domain/Profile/Tests/File.swift
+++ b/Projects/Domain/Profile/Tests/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  AppManifests
+//
+//  Created by YunhakLee on 2/22/26.
+//
+
+import Foundation

--- a/Projects/Domain/Profile/Tests/File.swift
+++ b/Projects/Domain/Profile/Tests/File.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  AppManifests
-//
-//  Created by YunhakLee on 2/22/26.
-//
-
-import Foundation

--- a/Projects/Domain/Profile/Tests/UseCase/LoadAccountInfoDraftUseCaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/LoadAccountInfoDraftUseCaseTests.swift
@@ -1,0 +1,55 @@
+//
+//  LoadAccountInfoDraftUseCaseTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  LoadAccountInfoDraftUseCaseTests.swift
+//  ProfileDomainTests
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("LoadAccountInfoDraftUseCase")
+struct LoadAccountInfoDraftUseCaseTests {
+
+    private func makeAccountInfoDraft() -> AccountInfoDraft {
+        // ✅ 프로젝트 타입에 맞게 여기만 조정하면 됨
+        AccountInfoDraft(email: "H@Gmail.com", gender: .female, birth: try! BirthYear(1990))
+    }
+
+    @Test("계정 정보 초안을 조회할 수 있다")
+    func loadsAccountInfoDraft() async throws {
+        let repo = MockProfileRepository()
+        let expected = makeAccountInfoDraft()
+        repo.loadAccountInfoDraftResult = .success(expected)
+
+        let sut = DefaultLoadAccountInfoDraftUseCase(repository: repo)
+
+        let result = try await sut.execute()
+
+        #expect(repo.loadAccountInfoDraftCallCount == 1)
+        #expect(result == expected)
+    }
+
+    @Test("조회 중 레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.loadAccountInfoDraftResult = .failure(.notFound)
+
+        let sut = DefaultLoadAccountInfoDraftUseCase(repository: repo)
+
+        await #expect(throws: RepositoryError.notFound) {
+            _ = try await sut.execute()
+        }
+
+        #expect(repo.loadAccountInfoDraftCallCount == 1)
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/LoadGenrePreferencesUsecaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/LoadGenrePreferencesUsecaseTests.swift
@@ -1,0 +1,66 @@
+//
+//  LoadGenrePreferencesUsecaseTests.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("LoadGenrePreferencesUsecase")
+struct LoadGenrePreferencesUsecaseTests {
+
+    @Test("장르 취향 목록을 반환한다")
+    func returnsGenrePreferences() async throws {
+        let repo = MockProfileRepository()
+        let expected = [makeGenre(name: "로맨스"), makeGenre(name: "판타지")]
+        repo.fetchGenrePreferencesResult = .success(expected)
+
+        let sut = DefaultLoadGenrePreferencesUsecase(profileRepository: repo)
+
+        let result = try await sut.execute(.me)
+
+        #expect(repo.fetchGenrePreferencesCallCount == 1)
+        guard case .me = repo.fetchedGenrePreferenceTargets.first else {
+            Issue.record(".me 타겟이 전달되어야 한다")
+            return
+        }
+        #expect(result == expected)
+    }
+
+    @Test("장르 취향이 없으면 빈 배열을 반환한다")
+    func returnsEmptyWhenNoGenrePreferences() async throws {
+        let repo = MockProfileRepository()
+        repo.fetchGenrePreferencesResult = .success([])
+
+        let sut = DefaultLoadGenrePreferencesUsecase(profileRepository: repo)
+
+        let result = try await sut.execute(.me)
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.fetchGenrePreferencesResult = .failure(.serverUnavailable)
+
+        let sut = DefaultLoadGenrePreferencesUsecase(profileRepository: repo)
+
+        await #expect(throws: RepositoryError.serverUnavailable) {
+            _ = try await sut.execute(.me)
+        }
+
+        #expect(repo.fetchGenrePreferencesCallCount == 1)
+    }
+}
+
+extension LoadGenrePreferencesUsecaseTests {
+
+    private func makeGenre(name: String = "로맨스") -> GenrePreference {
+        GenrePreference(name: name, image: nil, count: 0)
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/LoadNovelPreferencesUsecaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/LoadNovelPreferencesUsecaseTests.swift
@@ -1,0 +1,59 @@
+//
+//  LoadNovelPreferencesUsecaseTests.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("LoadNovelPreferencesUsecase")
+struct LoadNovelPreferencesUsecaseTests {
+
+    @Test("작품 취향을 반환한다")
+    func returnsNovelPreferences() async throws {
+        let repo = MockProfileRepository()
+        let expected = makeNovelPreference(attractivePoints: [.worldview, .character])
+        repo.fetchNovelPreferencesResult = .success(expected)
+
+        let sut = DefaultLoadNovelPreferencesUsecase(profileRepository: repo)
+
+        let result = try await sut.execute(.me)
+
+        #expect(repo.fetchNovelPreferencesCallCount == 1)
+        guard case .me = repo.fetchedNovelPreferenceTargets.first else {
+            Issue.record(".me 타겟이 전달되어야 한다")
+            return
+        }
+        #expect(result.attractivePoints == expected.attractivePoints)
+        #expect(result.keywords == expected.keywords)
+    }
+
+    @Test("레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.fetchNovelPreferencesResult = .failure(.serverUnavailable)
+
+        let sut = DefaultLoadNovelPreferencesUsecase(profileRepository: repo)
+
+        await #expect(throws: RepositoryError.serverUnavailable) {
+            _ = try await sut.execute(.me)
+        }
+
+        #expect(repo.fetchNovelPreferencesCallCount == 1)
+    }
+}
+
+extension LoadNovelPreferencesUsecaseTests {
+
+    private func makeNovelPreference(
+        attractivePoints: [AttractivePoint] = [],
+        keywords: [Keyword: Int] = [:]
+    ) -> NovelPreference {
+        NovelPreference(attractivePoints: attractivePoints, keywords: keywords)
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/LoadProfileCharacterUsecaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/LoadProfileCharacterUsecaseTests.swift
@@ -1,0 +1,73 @@
+//
+//  LoadProfileCharacterUsecaseTests.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("LoadProfileCharacterUsecase")
+struct LoadProfileCharacterUsecaseTests {
+
+    @Test("프로필 캐릭터 목록을 반환한다")
+    func returnsProfileCharacters() async throws {
+        let repo = MockProfileRepository()
+        let expected = [makeCharacter(id: 1, isRepresentative: true), makeCharacter(id: 2)]
+        repo.fetchProfileCharactersResult = .success(expected)
+
+        let sut = DefaultLoadProfileCharacterUsecase(profileRepository: repo)
+
+        let result = try await sut.execute()
+
+        #expect(repo.fetchProfileCharactersCallCount == 1)
+        #expect(result.count == 2)
+        #expect(result.first?.id == 1)
+    }
+
+    @Test("캐릭터가 없으면 빈 배열을 반환한다")
+    func returnsEmptyWhenNoCharacters() async throws {
+        let repo = MockProfileRepository()
+        repo.fetchProfileCharactersResult = .success([])
+
+        let sut = DefaultLoadProfileCharacterUsecase(profileRepository: repo)
+
+        let result = try await sut.execute()
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.fetchProfileCharactersResult = .failure(.serverUnavailable)
+
+        let sut = DefaultLoadProfileCharacterUsecase(profileRepository: repo)
+
+        await #expect(throws: RepositoryError.serverUnavailable) {
+            _ = try await sut.execute()
+        }
+
+        #expect(repo.fetchProfileCharactersCallCount == 1)
+    }
+}
+
+extension LoadProfileCharacterUsecaseTests {
+
+    private func makeCharacter(
+        id: Int = 1,
+        isRepresentative: Bool = false
+    ) -> ProfileCharacter {
+        ProfileCharacter(
+            id: id,
+            name: "캐릭터\(id)",
+            line: "한마디",
+            representativeImage: nil,
+            thumbnailImage: nil,
+            isRepresentative: isRepresentative
+        )
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/LoadProfileDraftUsecaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/LoadProfileDraftUsecaseTests.swift
@@ -1,0 +1,63 @@
+//
+//  LoadProfileDraftUsecaseTests.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("LoadProfileDraftUsecase")
+struct LoadProfileDraftUsecaseTests {
+
+    @Test("레포지토리에서 받은 ProfileDraft를 그대로 반환한다")
+    func returnsProfileDraftFromRepository() async throws {
+        let repo = MockProfileRepository()
+        let expected = makeProfileDraft()
+        repo.loadInitialProfileResult = .success(expected)
+
+        let sut = DefaultLoadProfileDraftUsecase(profileRepository: repo)
+
+        let result = try await sut.execute()
+
+        #expect(repo.loadInitialProfileCallCount == 1)
+        #expect(result.characterID == expected.characterID)
+        #expect(result.nickname.text == expected.nickname.text)
+        #expect(result.introduction == expected.introduction)
+        #expect(result.genrePreferences == expected.genrePreferences)
+    }
+
+    @Test("레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.loadInitialProfileResult = .failure(.serverUnavailable)
+
+        let sut = DefaultLoadProfileDraftUsecase(profileRepository: repo)
+
+        await #expect(throws: RepositoryError.serverUnavailable) {
+            _ = try await sut.execute()
+        }
+
+        #expect(repo.loadInitialProfileCallCount == 1)
+    }
+}
+
+extension LoadProfileDraftUsecaseTests {
+
+    private func makeProfileDraft(
+        characterID: Int = 1,
+        nickname: String = "서연",
+        introduction: String = "안녕하세요",
+        genrePreferences: [GenrePreference] = []
+    ) -> ProfileDraft {
+        ProfileDraft(
+            characterID: characterID,
+            nickname: nickname,
+            introduction: introduction,
+            genrePreferences: genrePreferences
+        )
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/LoadProfileUsecaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/LoadProfileUsecaseTests.swift
@@ -1,0 +1,84 @@
+//
+//  LoadProfileUsecaseTests.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("LoadProfileUsecase")
+struct LoadProfileUsecaseTests {
+
+    @Test(".me 타겟으로 프로필을 조회할 수 있다")
+    func loadsProfileWithMeTarget() async throws {
+        let repo = MockProfileRepository()
+        let expected = makeProfile()
+        repo.fetchUserProfileResult = .success(expected)
+
+        let sut = DefaultLoadProfileUsecase(profileRepository: repo)
+
+        let result = try await sut.execute(target: .me)
+
+        #expect(repo.fetchUserProfileCallCount == 1)
+        guard case .me = repo.fetchedUserProfileTargets.first else {
+            Issue.record(".me 타겟이 전달되어야 한다")
+            return
+        }
+        #expect(result.nickname == expected.nickname)
+        #expect(result.introduction == expected.introduction)
+        #expect(result.isPublic == expected.isPublic)
+    }
+
+    @Test(".user 타겟으로 다른 유저의 프로필을 조회할 수 있다")
+    func loadsProfileWithUserTarget() async throws {
+        let repo = MockProfileRepository()
+        repo.fetchUserProfileResult = .success(makeProfile(nickname: "다른유저"))
+
+        let sut = DefaultLoadProfileUsecase(profileRepository: repo)
+
+        _ = try await sut.execute(target: .user(UserID(42)))
+
+        #expect(repo.fetchUserProfileCallCount == 1)
+        guard case .user(let id) = repo.fetchedUserProfileTargets.first else {
+            Issue.record(".user 타겟이 전달되어야 한다")
+            return
+        }
+        #expect(id == UserID(42))
+    }
+
+    @Test("레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.fetchUserProfileResult = .failure(.serverUnavailable)
+
+        let sut = DefaultLoadProfileUsecase(profileRepository: repo)
+
+        await #expect(throws: RepositoryError.serverUnavailable) {
+            _ = try await sut.execute(target: .me)
+        }
+
+        #expect(repo.fetchUserProfileCallCount == 1)
+    }
+}
+
+extension LoadProfileUsecaseTests {
+
+    private func makeProfile(
+        nickname: String = "서연",
+        introduction: String = "안녕하세요",
+        isPublic: Bool = true
+    ) -> Profile {
+        Profile(
+            nickname: nickname,
+            introduction: introduction,
+            characterImage: nil,
+            isPublic: isPublic,
+            genrePreferences: []
+        )
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/LoadProfileVisibilityUseCaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/LoadProfileVisibilityUseCaseTests.swift
@@ -1,0 +1,50 @@
+//
+//  LoadProfileVisibilityUseCaseTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  LoadProfileVisibilityUseCaseTests.swift
+//  ProfileDomainTests
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("LoadProfileVisibilityUseCase")
+struct LoadProfileVisibilityUseCaseTests {
+
+    @Test("프로필 공개 여부를 조회할 수 있다")
+    func loadsProfileVisibility() async throws {
+        let repo = MockProfileRepository()
+        let expected = ProfileVisibility(isPublic: true)
+        repo.loadProfileVisibilityResult = .success(expected)
+
+        let sut = DefaultLoadProfileVisibilityUseCase(repository: repo)
+
+        let result = try await sut.execute()
+
+        #expect(repo.loadProfileVisibilityCallCount == 1)
+        #expect(result == expected)
+    }
+
+    @Test("조회 중 레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.loadProfileVisibilityResult = .failure(.networkUnavailable)
+
+        let sut = DefaultLoadProfileVisibilityUseCase(repository: repo)
+
+        await #expect(throws: RepositoryError.networkUnavailable) {
+            _ = try await sut.execute()
+        }
+
+        #expect(repo.loadProfileVisibilityCallCount == 1)
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/RegisterProfileUseCaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/RegisterProfileUseCaseTests.swift
@@ -1,0 +1,60 @@
+//
+//  RegisterProfileUseCaseTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  RegisterProfileUseCaseTests.swift
+//  ProfileDomainTests
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("RegisterProfileUseCase")
+struct RegisterProfileUseCaseTests {
+
+    private func makeProfileRegistration() -> ProfileRegistration {
+        // ✅ 프로젝트 타입에 맞게 여기만 조정하면 됨
+        ProfileRegistration(
+            nickname: "밝보",
+            gender: .male,
+            birthYear: try! BirthYear(2002),
+            genrePreferences: [.romance, .wuxia]
+        )
+    }
+
+    @Test("프로필을 최초 등록할 수 있다")
+    func registersProfile() async throws {
+        let repo = MockProfileRepository()
+        repo.registerProfileResult = .success(())
+
+        let sut = DefaultRegisterProfileUseCase(repository: repo)
+        let profile = makeProfileRegistration()
+
+        try await sut.execute(profile)
+
+        #expect(repo.registerProfileCallCount == 1)
+        #expect(repo.registeredProfiles == [profile])
+    }
+
+    @Test("등록 중 레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.registerProfileResult = .failure(.authenticationRequired)
+
+        let sut = DefaultRegisterProfileUseCase(repository: repo)
+
+        await #expect(throws: RepositoryError.authenticationRequired) {
+            try await sut.execute(makeProfileRegistration())
+        }
+
+        #expect(repo.registerProfileCallCount == 1)
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/SaveAccountInfoDraftUseCaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/SaveAccountInfoDraftUseCaseTests.swift
@@ -1,0 +1,55 @@
+//
+//  SaveAccountInfoDraftUseCaseTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  SaveAccountInfoDraftUseCaseTests.swift
+//  ProfileDomainTests
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("SaveAccountInfoDraftUseCase")
+struct SaveAccountInfoDraftUseCaseTests {
+
+    private func makeAccountInfoDraft() -> AccountInfoDraft {
+        // ✅ 프로젝트 타입에 맞게 여기만 조정하면 됨
+        AccountInfoDraft(email: "H@Gmail.com", gender: .female, birth: try! BirthYear(1990))
+    }
+
+    @Test("계정 정보 초안을 저장할 수 있다")
+    func savesAccountInfoDraft() async throws {
+        let repo = MockProfileRepository()
+        repo.saveAccountInfoResult = .success(())
+
+        let sut = DefaultSaveAccountInfoDraftUseCase(repository: repo)
+        let info = makeAccountInfoDraft()
+
+        try await sut.execute(info)
+
+        #expect(repo.saveAccountInfoCallCount == 1)
+        #expect(repo.savedAccountInfos == [info])
+    }
+
+    @Test("저장 중 레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.saveAccountInfoResult = .failure(.serverUnavailable)
+
+        let sut = DefaultSaveAccountInfoDraftUseCase(repository: repo)
+
+        await #expect(throws: RepositoryError.serverUnavailable) {
+            try await sut.execute(makeAccountInfoDraft())
+        }
+
+        #expect(repo.saveAccountInfoCallCount == 1)
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/SyncUserBasicInfoUseCaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/SyncUserBasicInfoUseCaseTests.swift
@@ -1,0 +1,48 @@
+//
+//  SyncUserBasicInfoUseCaseTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  SyncUserBasicInfoUseCaseTests.swift
+//  ProfileDomainTests
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("SyncUserBasicInfoUseCase")
+struct SyncUserBasicInfoUseCaseTests {
+
+    @Test("유저 기본 정보를 동기화할 수 있다")
+    func syncsUserBasicInfo() async throws {
+        let repo = MockProfileRepository()
+        repo.syncUserBasicInfoResult = .success(())
+
+        let sut = DefaultSyncUserBasicInfoUseCase(repository: repo)
+
+        try await sut.execute()
+
+        #expect(repo.syncUserBasicInfoCallCount == 1)
+    }
+
+    @Test("동기화 중 레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.syncUserBasicInfoResult = .failure(.networkUnavailable)
+
+        let sut = DefaultSyncUserBasicInfoUseCase(repository: repo)
+
+        await #expect(throws: RepositoryError.networkUnavailable) {
+            try await sut.execute()
+        }
+
+        #expect(repo.syncUserBasicInfoCallCount == 1)
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/UpdateProfileUsecaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/UpdateProfileUsecaseTests.swift
@@ -1,0 +1,63 @@
+//
+//  UpdateProfileUsecaseTests.swift
+//  ProfileDomain
+//
+//  Created by Seoyeon Choi on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("UpdateProfileUsecase")
+struct UpdateProfileUsecaseTests {
+
+    @Test("레포지토리의 updateProfile이 draft와 함께 호출된다")
+    func callsUpdateProfileWithGivenDraft() async throws {
+        let repo = MockProfileRepository()
+        repo.updateProfileResult = .success(())
+        let draft = makeProfileDraft(characterID: 5, nickname: "newNick", introduction: "새 소개글")
+
+        let sut = DefaultUpdateProfileUsecase(profileRepository: repo)
+
+        try await sut.execute(draft)
+
+        #expect(repo.updateProfileCallCount == 1)
+        #expect(repo.updatedDrafts.first?.characterID == 5)
+        #expect(repo.updatedDrafts.first?.nickname.text == "newNick")
+        #expect(repo.updatedDrafts.first?.introduction == "새 소개글")
+    }
+
+    @Test("레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.updateProfileResult = .failure(.serverUnavailable)
+        let draft = makeProfileDraft()
+
+        let sut = DefaultUpdateProfileUsecase(profileRepository: repo)
+
+        await #expect(throws: RepositoryError.serverUnavailable) {
+            try await sut.execute(draft)
+        }
+
+        #expect(repo.updateProfileCallCount == 1)
+    }
+}
+
+extension UpdateProfileUsecaseTests {
+
+    private func makeProfileDraft(
+        characterID: Int = 1,
+        nickname: String = "서연",
+        introduction: String = "안녕하세요",
+        genrePreferences: [GenrePreference] = []
+    ) -> ProfileDraft {
+        ProfileDraft(
+            characterID: characterID,
+            nickname: nickname,
+            introduction: introduction,
+            genrePreferences: genrePreferences
+        )
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/UpdateProfileVisibilityUseCaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/UpdateProfileVisibilityUseCaseTests.swift
@@ -1,0 +1,50 @@
+//
+//  UpdateProfileVisibilityUseCaseTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  UpdateProfileVisibilityUseCaseTests.swift
+//  ProfileDomainTests
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("UpdateProfileVisibilityUseCase")
+struct UpdateProfileVisibilityUseCaseTests {
+
+    @Test("프로필 공개 여부를 변경할 수 있다")
+    func updatesProfileVisibility() async throws {
+        let repo = MockProfileRepository()
+        repo.updateProfileVisibilityResult = .success(())
+
+        let sut = DefaultUpdateProfileVisibilityUseCase(repository: repo)
+        let visibility = ProfileVisibility(isPublic: false)
+
+        try await sut.execute(visibility)
+
+        #expect(repo.updateProfileVisibilityCallCount == 1)
+        #expect(repo.updatedVisibilities == [visibility])
+    }
+
+    @Test("변경 중 레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.updateProfileVisibilityResult = .failure(.authenticationRequired)
+
+        let sut = DefaultUpdateProfileVisibilityUseCase(repository: repo)
+
+        await #expect(throws: RepositoryError.authenticationRequired) {
+            try await sut.execute(ProfileVisibility(isPublic: true))
+        }
+
+        #expect(repo.updateProfileVisibilityCallCount == 1)
+    }
+}

--- a/Projects/Domain/Profile/Tests/UseCase/ValidateNicknameUseCaseTests.swift
+++ b/Projects/Domain/Profile/Tests/UseCase/ValidateNicknameUseCaseTests.swift
@@ -1,0 +1,50 @@
+//
+//  ValidateNicknameUseCaseTests.swift
+//  ProfileDomain
+//
+//  Created by YunhakLee on 2/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+
+//
+//  ValidateNicknameUseCaseTests.swift
+//  ProfileDomainTests
+//
+
+import Testing
+import BaseDomain
+@testable import ProfileDomain
+@testable import ProfileDomainTesting
+
+@Suite("ValidateNicknameUseCase")
+struct ValidateNicknameUseCaseTests {
+
+    @Test("닉네임 중복 여부를 조회할 수 있다")
+    func returnsDuplicationStatus() async throws {
+        let repo = MockProfileRepository()
+        repo.validateNicknameResult = .success(true)
+
+        let sut = DefaultValidateNicknameUseCase(repository: repo)
+
+        let isDuplicated = try await sut.execute("갑갑")
+
+        #expect(repo.validateNicknameCallCount == 1)
+        #expect(repo.validatedNicknames == ["갑갑"])
+        #expect(isDuplicated == true)
+    }
+
+    @Test("조회 중 레포지토리에서 에러가 발생하면 그대로 전달한다")
+    func propagatesRepositoryError() async {
+        let repo = MockProfileRepository()
+        repo.validateNicknameResult = .failure(.serverUnavailable)
+
+        let sut = DefaultValidateNicknameUseCase(repository: repo)
+
+        await #expect(throws: RepositoryError.serverUnavailable) {
+            _ = try await sut.execute("갑갑")
+        }
+
+        #expect(repo.validateNicknameCallCount == 1)
+    }
+}


### PR DESCRIPTION
## 💡 Issue
<!-- closed #1 -->
- closed #48 
- closed #38 
  - 나기가 구현한 것도 같이 ..?

<br>

## 💭 Summary
<!-- 작업에 대한 간단한 소개 -->
ProfileDomain 모듈을 구현했습니다. 

Profile Domain - 각 기능 이름은 API 명세에서 가져옴
• 유저 정보 조회
• 닉네임 유효성 확인
• 서버 에러 응답에 따라 UI 처리 필요. 피그마를 보고 필요한 case 별로 error. 설정
• 닉네임, 성별, 출생년도, 취향 등록
• 온보딩 마무리에 사용
• 타 유저/본인 프로필 조회, 유저 프로필 수정
• 조회의 경우, 한 repository 메서드에 내꺼/타인꺼 (userlD) 형태의 enum 입력을 받는 형태로 구현하면 될 듯.
• 유저 장르/작품 취향 조회
• 프로필 아바타 목록 조회
• 유저 등록 작품 수 조회
• 유저 계정정보 조회 / 수정
• 유저 프로필 공개 여부 조회/ 수정

<br>

## 🔑 Key Changes
<!-- 작업에 대한 구체적인 설명 -->
- 유저 등록 작품 수 조회 Usecase를 NovelDomain에 포함되도록 했습니다. 
<img width="764" height="356" alt="image" src="https://github.com/user-attachments/assets/79509b3a-ea46-4f47-99b8-9259fa1d951c" />

이유는 유저가 **등록한 작품 수**를 조회하는 것이기 때문에, 
ProfileDomain의 의미보단 NovelDomain에 포함되는 것이 적합하다고 판단했기 때문입니다!
의견이 다르다면 언제든지 환영!
<br>

## 📱 Simulation
<!-- 작업에 대한 UI 시뮬레이터 -->

<br>

## 🧑‍🧒‍🧒 To Reviewer
<!-- 리뷰어에게 전달할 내용 -->

<br>

## ※ Reference
<!-- 작업 시 참고한 레퍼런스 -->
