### PR TITLE
[Chore?] - #57 NovelReview Domain 서버 데이터 오염 관련 로직 수정

### DIFF
--- a/Projects/Domain/NovelReview/Sources/Entity/NovelReviewDraft.swift
+++ b/Projects/Domain/NovelReview/Sources/Entity/NovelReviewDraft.swift
@@ -38,29 +38,12 @@ public struct NovelReviewDraft: Equatable {
         attractivePoints: [AttractivePoint],
         keywords: [Keyword]
     ) {
-        let uniqueAttractivePoints = Array(Set(attractivePoints))
-        let uniqueKeywords = Array(Set(keywords))
-#if DEBUG
-        if uniqueAttractivePoints.count != attractivePoints.count {
-            assertionFailure("AttractivePoints contains duplicates")
-        }
-        if uniqueKeywords.count != keywords.count {
-            assertionFailure("Keywords contains duplicates")
-        }
-        if uniqueAttractivePoints.count > Self.maxAttractivePoints {
-            assertionFailure("AttractivePoints overflow: \(uniqueAttractivePoints.count) (max: \(Self.maxAttractivePoints))")
-        }
-        if uniqueKeywords.count > Self.maxKeywords {
-            assertionFailure("Keywords overflow: \(uniqueKeywords.count) (max: \(Self.maxKeywords))")
-        }
-#endif
-        
         self.novelID = novelID
         self.status = status
         self.period = period?.normalized(for: status)
         self.rating = rating
-        self.attractivePoints = Array(uniqueAttractivePoints.prefix(Self.maxAttractivePoints))
-        self.keywords = Array(uniqueKeywords.prefix(Self.maxKeywords))
+        self.attractivePoints = attractivePoints
+        self.keywords = keywords
     }
     
     // MARK: - Draft Editing

--- a/Projects/Domain/NovelReview/Sources/Entity/NovelReviewDraft.swift
+++ b/Projects/Domain/NovelReview/Sources/Entity/NovelReviewDraft.swift
@@ -21,11 +21,9 @@ public struct NovelReviewDraft: Equatable {
     // MARK: - Policy
     
     private static let maxAttractivePoints = 3
-    private static let maxKeywords = 20
     
     public enum ValidationError: Error, Equatable {
         case tooManyAttractivePoints(max: Int)
-        case tooManyKeywords(max: Int)
     }
     
     // MARK: - Init
@@ -76,16 +74,7 @@ public struct NovelReviewDraft: Equatable {
     }
     
     public mutating func setKeywords(_ newKeywords: [Keyword]) throws {
-        let uniqueKeywords = Array(Set(newKeywords))
-#if DEBUG
-        if uniqueKeywords.count != newKeywords.count {
-            assertionFailure("Keywords contains duplicates")
-        }
-#endif
-        guard uniqueKeywords.count <= Self.maxKeywords else {
-            throw ValidationError.tooManyKeywords(max: Self.maxKeywords)
-        }
-        keywords = uniqueKeywords
+        keywords = newKeywords
     }
     
     public mutating func removeKeyword(_ keyword: Keyword) {

--- a/Projects/Domain/NovelReview/Tests/Entity/NovelReviewDraftTests.swift
+++ b/Projects/Domain/NovelReview/Tests/Entity/NovelReviewDraftTests.swift
@@ -41,33 +41,6 @@ struct NovelReviewDraftTests {
 
     // MARK: - Init rules
 
-    @Test("초기화 시 매력 포인트는 중복이 제거되고 최대 3개까지만 유지된다")
-    func initNormalizesAttractivePoints() {
-        // duplicates + more than 3
-        let input: [AttractivePoint] = [
-            .worldview, .worldview, .material, .character, .relationship, .character
-        ]
-
-        let draft = makeDraft(attractivePoints: input)
-
-        // max 3
-        #expect(draft.attractivePoints.count == 3)
-        // unique
-        #expect(Set(draft.attractivePoints).count == draft.attractivePoints.count)
-    }
-
-    @Test("초기화 시 키워드는 중복이 제거되고 최대 20개까지만 유지된다")
-    func initNormalizesKeywords() {
-        // 25 items with duplicates
-        let base = (1...25).map(makeKeyword)
-        let input = base + [makeKeyword(1), makeKeyword(2), makeKeyword(3)] // duplicates
-
-        let draft = makeDraft(keywords: input)
-
-        #expect(draft.keywords.count == 20)
-        #expect(Set(draft.keywords).count == draft.keywords.count)
-    }
-
     @Test("초기화 시 읽기 상태에 따라 기간이 정규화된다")
     func initNormalizesPeriodByStatus() throws {
         let d = Date(timeIntervalSince1970: 1_700_000_000)
@@ -253,17 +226,7 @@ struct NovelReviewDraftTests {
 
     // MARK: - Keywords editing rules
 
-    @Test("키워드를 20개 초과로 설정하면 예외가 발생한다")
-    func setKeywordsThrowsOnOverflow() async throws {
-        var draft = makeDraft()
-        let twentyOne = (1...21).map(makeKeyword)
-
-        #expect(throws: NovelReviewDraft.ValidationError.tooManyKeywords(max: 20)) {
-            try draft.setKeywords(twentyOne)
-        }
-    }
-
-    @Test("키워드는 20개 이하일 경우 정상적으로 설정된다")
+    @Test("키워드는 받은 입력값을 그대로 설정된다")
     func setKeywordsAcceptsUnderMax() throws {
         var draft = makeDraft()
         let input = (1...20).map(makeKeyword)


### PR DESCRIPTION
## 💡 Issue
<!-- closed #1 -->
#57 
<br>

## 💭 Summary
<!-- 작업에 대한 간단한 소개 -->
- Domain Module 자체에서는 서버 데이터가 오염된 상황을 걱정할 필요가 없는 것으로,, 결론 내렸습니다!
- 대신, Mapper에서! DTO를 Entity로 변경할 때 서버 데이터 에러를 잡고, 내부적으로 log를 남기고 외부로는 unknown 에러를 던지는 것으로 갑시다!
<br>

## 🔑 Key Changes
<!-- 작업에 대한 구체적인 설명 -->
- 기존에 서버 데이터 오염을 염두에 둔 init 로직을 제거
- keyword view에서 잘못된 값을 전달해주는 것을 염두에 둔 로직을 제거.
<br>

