### PR TITLE
[Feat] #81 - BaseData 모듈 구현

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
@@ -44,6 +44,7 @@ public enum DomainModule: String, ModuleSpec {
 public enum DataModule: String, ModuleSpec {
     public var moduleSuffix: String { "Data" }
     
+    case base
     case recommendation
     case novelReview
     case notification

--- a/Projects/Data/BaseData/Project.swift
+++ b/Projects/Data/BaseData/Project.swift
@@ -1,0 +1,20 @@
+//
+//  Project.swift
+//  Manifests
+//
+//  Created by Wonsun Lee on 4/13/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.createDataModule(
+    name: ModuleType.Data.base.name,
+    targets: [.sources],
+    internalDependencies: [
+        .Core.Networking,
+        .Core.Logger,
+        .Domain.BaseDomain
+    ]
+)

--- a/Projects/Data/BaseData/Sources/Error/MappingError.swift
+++ b/Projects/Data/BaseData/Sources/Error/MappingError.swift
@@ -1,0 +1,26 @@
+//
+//  MappingError.swift
+//  BaseData
+//
+//  Created by Wonsun Lee on 4/13/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+/// DTO → 도메인 enum 변환 실패 시 Mapper가 throw하는 공통 에러.
+/// - type: 변환 대상 타입 이름 (각 모듈이 자유롭게 정의)
+/// - value: 변환에 실패한 원본 서버 raw string
+public enum MappingError: Error, Equatable, CustomStringConvertible {
+    case invalidConversion(type: String, value: String)
+    case invalidPayload(reason: String)  // 각 모듈에서 payload 정의하여 String 타입의 description으로 전달
+
+    public var description: String {
+        switch self {
+        case let .invalidConversion(type, value):
+            return "❌ Failed to convert '\(value)' to \(type)"
+        case let .invalidPayload(reason):
+            return "❌ Invalid payload: \(reason)"
+        }
+    }
+}

--- a/Projects/Data/BaseData/Sources/Error/MappingError.swift
+++ b/Projects/Data/BaseData/Sources/Error/MappingError.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 
-/// DTO → 도메인 enum 변환 실패 시 Mapper가 throw하는 공통 에러.
-/// - type: 변환 대상 타입 이름 (각 모듈이 자유롭게 정의)
-/// - value: 변환에 실패한 원본 서버 raw string
+/// DTO → 도메인 enum 변환 실패 시 Mapper가 throw하는 공통 에러
 public enum MappingError: Error, Equatable, CustomStringConvertible {
     case invalidConversion(type: String, value: String)
     case invalidPayload(reason: String)  // 각 모듈에서 payload 정의하여 String 타입의 description으로 전달

--- a/Projects/Data/BaseData/Sources/Logging/DataLogger.swift
+++ b/Projects/Data/BaseData/Sources/Logging/DataLogger.swift
@@ -10,7 +10,6 @@ import Logger
 import Networking
 
 /// Data 레이어 Repository용 구조화 로거.
-/// 모듈 이름을 prefix로 갖는 일관된 포맷으로 에러를 기록.
 public struct DataLogger {
     private let moduleName: String
     private let underlying: Logger?

--- a/Projects/Data/BaseData/Sources/Logging/DataLogger.swift
+++ b/Projects/Data/BaseData/Sources/Logging/DataLogger.swift
@@ -1,0 +1,41 @@
+//
+//  DataLogger.swift
+//  BaseData
+//
+//  Created by Wonsun Lee on 4/13/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Logger
+import Networking
+
+/// Data 레이어 Repository용 구조화 로거.
+/// 모듈 이름을 prefix로 갖는 일관된 포맷으로 에러를 기록.
+public struct DataLogger {
+    private let moduleName: String
+    private let underlying: Logger?
+
+    public init(moduleName: String, underlying: Logger? = nil) {
+        self.moduleName = moduleName
+        self.underlying = underlying
+    }
+
+    /// NetworkingError catch 블록에서 사용
+    public func logNetworkError(action: String, error: NetworkingError) {
+        underlying?.error("❌ [\(moduleName)] \(action) network error: \(error)")
+    }
+
+    /// MappingError catch 블록에서 사용
+    public func logMappingError(action: String, error: MappingError) {
+        underlying?.error("❌ [\(moduleName)] \(action) mapping error: \(error)")
+    }
+
+    /// 나머지 catch 블록에서 사용
+    public func logUnknownError(action: String, error: Error) {
+        underlying?.error("❌ [\(moduleName)] \(action) unknown error: \(error)")
+    }
+
+    public func logSuccess(action: String) {
+        underlying?.debug("✅ [\(moduleName)] \(action) succeeded")
+    }
+}

--- a/Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift
+++ b/Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift
@@ -10,7 +10,6 @@ import Networking
 import BaseDomain
 
 /// HTTP 상태 코드 → RepositoryError 변환
-/// 모든 Data 모듈이 이 extension을 공유하여 에러 매핑 정책을 일관되게 유지.
 public extension NetworkingError {
     func toRepositoryError() -> RepositoryError {
         switch self {

--- a/Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift
+++ b/Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift
@@ -1,0 +1,32 @@
+//
+//  NetworkingError+RepositoryError.swift
+//  BaseData
+//
+//  Created by Wonsun Lee on 4/13/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Networking
+import BaseDomain
+
+/// HTTP 상태 코드 → RepositoryError 변환
+/// 모든 Data 모듈이 이 extension을 공유하여 에러 매핑 정책을 일관되게 유지.
+public extension NetworkingError {
+    func toRepositoryError() -> RepositoryError {
+        switch self {
+        case .invalidURL:
+            return .unknown
+        case .decoding:
+            return .invalidData
+        case .responseFailure(let code, _):
+            switch code {
+            case 401: return .authenticationRequired
+            case 404:      return .notFound
+            case 500...599: return .serverUnavailable
+            default:       return .unknown
+            }
+        case .unknown:
+            return .networkUnavailable
+        }
+    }
+}


### PR DESCRIPTION
## 💡 Issue
 #81

  <br>

  ## 💭 Summary
  Data 레이어 전체에서 공통으로 사용할 BaseData 모듈을 구현했습니다.
  에러 처리 / 로깅 / 도메인 에러 변환을 각 Data 모듈이 일관된 방식으로 처리할 수 있도록 공통 인프라를 제공합니다.

  <br>

  ## 🔑 Key Changes
  - **BaseData 모듈 생성**: Tuist 프로젝트 설정 및 `ModuleType`에 `baseData` 케이스 추가
  - **`MappingError` 정의**: DTO → 도메인 enum 변환 실패 시 Mapper가 throw하는 공통 에러 타입
    - `invalidConversion(type:value:)`: raw string → 특정 타입 변환 실패
    - `invalidPayload(reason:)`: 페이로드 자체가 유효하지 않은 경우
  - **`DataLogger` 정의**: Data 레이어 Repository용 구조화 로거
    - 모듈 이름을 prefix로 포함하는 일관된 로그 포맷 제공
    - `logNetworkError` / `logMappingError` / `logUnknownError` / `logSuccess` 메서드 제공
  - **`NetworkingError+RepositoryError` extension 구현**: `NetworkingError` → `RepositoryError` 변환 정책을 한
  곳에서 관리
    - 401 → `authenticationRequired`, 404 → `notFound`, 5xx → `serverUnavailable` 등

  <br>

  ## 📱 Simulation
  해당 없음 (UI 없는 모듈 작업)

  <br>

  ## 🧑‍🧒‍🧒 To Reviewer
  - BaseData는 각 Data 모듈(`CommentData`, `FeedData` 등)이 의존하는 공통 인프라 모듈입니다.
  - `NetworkingError → RepositoryError` 변환 케이스 중 빠진 HTTP 코드가 있다면 의견 주세요.
  - `MappingError`의 케이스 설계가 충분한지 확인 부탁드립니다.

  <br>

  ## ※ Reference
  - 없음