### PR TITLE
[Feat] #83 - OSLog 기반 Logger 구현체 추가

### DIFF
--- a/Projects/Core/Logger/Sources/OSLogger.swift
+++ b/Projects/Core/Logger/Sources/OSLogger.swift
@@ -10,7 +10,6 @@ import Foundation
 import os
 
 /// OSLog 기반 Logger 구현체
-/// Console.app에서 subsystem / category 로 필터링 가능
 public final class OSLogger: Logger {
     private let logger: os.Logger
 

--- a/Projects/Core/Logger/Sources/OSLogger.swift
+++ b/Projects/Core/Logger/Sources/OSLogger.swift
@@ -1,0 +1,57 @@
+//
+//  OSLogger.swift
+//  Logger
+//
+//  Created by Seoyeon Choi on 3/27/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import os
+
+/// OSLog 기반 Logger 구현체
+/// Console.app에서 subsystem / category 로 필터링 가능
+public final class OSLogger: Logger {
+    private let logger: os.Logger
+
+    public init(subsystem: String = Bundle.main.bundleIdentifier ?? "kr.websoso.app",
+                category: LogCategory) {
+        self.logger = os.Logger(subsystem: subsystem, category: category.rawValue)
+    }
+
+    public func debug(_ message: String) {
+        logger.debug("\(message, privacy: .public)")
+    }
+
+    public func info(_ message: String) {
+        logger.info("\(message, privacy: .public)")
+    }
+
+    public func error(_ message: String) {
+        logger.error("\(message, privacy: .public)")
+    }
+}
+
+// MARK: - Shared Instances
+
+public extension OSLogger {
+    static let network      = OSLogger(category: .network)
+    static let auth         = OSLogger(category: .auth)
+    static let ui           = OSLogger(category: .ui)
+    static let general      = OSLogger(category: .general)
+    static let novel        = OSLogger(category: .novel)
+    static let notification = OSLogger(category: .notification)
+    static let feed         = OSLogger(category: .feed)
+}
+
+// MARK: - LogCategory
+
+public enum LogCategory: String {
+    case network
+    case auth
+    case ui
+    case general
+    case novel
+    case notification
+    case feed
+}

--- a/Tuist/ProjectDescriptionHelpers/ModuleInfoPlist.swift
+++ b/Tuist/ProjectDescriptionHelpers/ModuleInfoPlist.swift
@@ -15,36 +15,33 @@ public enum ModuleInfoPlist {
     case core
     case ui
     
+    private var commonEntries: [String: Plist.Value] {
+        [
+            "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+            "CFBundleName": "$(TARGET_NAME)",
+            "UILaunchScreen": .dictionary([:]),
+            "UISupportedInterfaceOrientations~ipad": .array([
+                .string("UIInterfaceOrientationPortrait")
+            ])
+        ]
+    }
+    
     public var dictionary: [String: Plist.Value] {
         switch self {
         case .feature:
-            return [
-                "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
-                "CFBundleName": "$(TARGET_NAME)"
-            ]
+            return commonEntries
         case .domain:
-            return [
-                "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
-                "CFBundleName": "$(TARGET_NAME)"
-            ]
+            return commonEntries
         case .data:
-            return [
-                "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
-                "CFBundleName": "$(TARGET_NAME)",
-                "AMPLITUDE_API_KEY": "$(AMPLITUDE_API_KEY)",
-                "BASE_URL": "$(BASE_URL)",
-                "TEST_API_KEY": "$(TEST_API_KEY)"
-            ]
+            var entries = commonEntries
+            entries["AMPLITUDE_API_KEY"] = "$(AMPLITUDE_API_KEY)"
+            entries["BASE_URL"] = "$(BASE_URL)"
+            entries["TEST_API_KEY"] = "$(TEST_API_KEY)"
+            return entries
         case .core:
-            return [
-                "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
-                "CFBundleName": "$(TARGET_NAME)"
-            ]
+            return commonEntries
         case .ui:
-            return [
-                "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
-                "CFBundleName": "$(TARGET_NAME)"
-            ]
+            return commonEntries
         }
     }
     


### PR DESCRIPTION
## 💡 Issue
<!-- closed #1 -->
- closed #83 
<br>
                                                                                                                    
                  
                                                          

## 💭 Summary
<!-- 작업에 대한 간단한 소개 -->
- Logger 프로토콜의 OSLog 기반 구현체인 **OSLogger**를 추가했습니다.                                                                 
  - 기존 ConsoleLogger가 print()를 사용하는 반면, 
  OSLogger는 **Apple의 os.Logger**를 활용해 Instruments, Console.app 등 시스템 로깅 도구와 연동될 수 있습니다.                                                                                                             
  - 도메인/레이어별 싱글톤 인스턴스를 static let으로 제공해 사용 편의성을  높였습니다.       
<br>

## 🔑 Key Changes
<!-- 작업에 대한 구체적인 설명 -->
### LogCategory 추가 이유
1. Apple의 `os.Logger`는 subsystem과 category를 **초기화 시점에 단 한 번만** 설정할 수 있고, 이후에는 변경할 수 없습니다.
                                                                                                                                 
  ```swift        
  // os.Logger는 생성 이후 category 변경 불가
  os.Logger(subsystem: "kr.websoso.app", category: "novel")                                                                      
```
                                                                    
  따라서 카테고리별로 별도 인스턴스가 필요하고, 이를 외부에서 주입받는 구조가 됩니다.                                            
                                                                                                                                 
  2. 도메인별 로그 필터링                                                                                                           
                  
  카테고리를 분리하면 Console.app 또는 터미널에서 도메인 단위로 로그를 필터링할 수 있습니다.                                     
   
```
  log stream --predicate 'category == "novel"'                                                                                   
  log stream --predicate 'category == "network"'
```
  카테고리 없이 단일 인스턴스를 사용하면 모든 로그가 동일 카테고리로 묶여서 디버깅 시 원하는 도메인의 로그를 분리해서 보기 어려워지게 됩니다.
<br>

## 📱 Simulation
<!-- 작업에 대한 UI 시뮬레이터 -->
<img width="1003" height="370" alt="image" src="https://github.com/user-attachments/assets/e52d8792-e791-41b6-aa56-926d12b07f0b" />

<br>

### Tuist 시뮬레이션 비율 깨지는 문제 사항 해결 
`UILaunchScreen`이 없으면 iOS가 앱을 레거시 호환 모드로 실행하여 해상도를 스케일링하기 때문에, 최신 디바이스에서 UI가 살짝 확대되어 보이는 문제가 발생했습니다.
- `UILaunchScreen` 추가 — iPhone 17 Pro에서 화면이 늘어져 보이는 문제 수정
- `UISupportedInterfaceOrientations~ipad` 추가 (Portrait 방향만 지원)
 
| 이전 | 이후 | 
| -- | -- | 
| <img width="200" height="400" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-15 at 00 45 19" src="https://github.com/user-attachments/assets/832fd5c0-db32-4628-a88c-e9f8336f8de5" /> | <img width="200" height="400" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-15 at 00 40 36" src="https://github.com/user-attachments/assets/eac3a601-52d5-4b2f-9974-ba5cd5e79348" /> | 


<br>

## 🧑‍🧒‍🧒 To Reviewer
<!-- 리뷰어에게 전달할 내용 -->

<br>

## ※ Reference
<!-- 작업 시 참고한 레퍼런스 -->
