### PR TITLE
[Feat] #87 - SocialData 모듈 구현

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
@@ -43,7 +43,7 @@ public enum DomainModule: String, ModuleSpec {
 
 public enum DataModule: String, ModuleSpec {
     public var moduleSuffix: String { "Data" }
-    
+
     case base
     case recommendation
     case novelReview
@@ -52,6 +52,7 @@ public enum DataModule: String, ModuleSpec {
     case keyword
     case comment
     case auth
+    case social
 }
 
 public enum CoreModule: String, ModuleSpec {

--- a/Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift
+++ b/Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift
@@ -26,6 +26,8 @@ public extension NetworkingError {
             }
         case .unknown:
             return .networkUnavailable
+        case .requiresReauthentication:
+            return .authenticationRequired
         }
     }
 }

--- a/Projects/Data/SocialData/Demo/SocialDataDemoApp.swift
+++ b/Projects/Data/SocialData/Demo/SocialDataDemoApp.swift
@@ -1,0 +1,19 @@
+//
+//  SocialDataDemoApp.swift
+//  SocialDataDemo
+//
+//  Created by WonsunLee on 5/1/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import SwiftUI
+import SocialData
+
+@main
+struct SocialDataDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            SocialDataDemoView()
+        }
+    }
+}

--- a/Projects/Data/SocialData/Demo/SocialDataDemoView.swift
+++ b/Projects/Data/SocialData/Demo/SocialDataDemoView.swift
@@ -18,6 +18,7 @@ struct SocialDataDemoView: View {
     @State private var userIDText: String = ""
     @State private var blockIDText: String = ""
     @State private var feedIDText: String = ""
+    @State private var commentFeedIDText: String = ""
     @State private var commentIDText: String = ""
     @State private var isLoading: Bool = false
 
@@ -106,7 +107,7 @@ struct SocialDataDemoView: View {
             Text("Report Comment").font(.headline).padding(.horizontal)
 
             HStack {
-                TextField("피드 ID", text: $feedIDText)
+                TextField("피드 ID", text: $commentFeedIDText)
                     .textFieldStyle(.roundedBorder)
                     .keyboardType(.numberPad)
                 TextField("댓글 ID", text: $commentIDText)
@@ -176,6 +177,11 @@ struct SocialDataDemoView: View {
         return FeedID(value)
     }
 
+    private var commentFeedID: FeedID? {
+        guard let value = Int(commentFeedIDText) else { return nil }
+        return FeedID(value)
+    }
+
     private var commentID: CommentID? {
         guard let value = Int(commentIDText) else { return nil }
         return CommentID(value)
@@ -242,28 +248,28 @@ struct SocialDataDemoView: View {
     }
 
     private func reportSpoilerComment() async {
-        guard let feedID else { log = "피드 ID를 입력해주세요."; return }
+        guard let commentFeedID else { log = "피드 ID를 입력해주세요."; return }
         guard let commentID else { log = "댓글 ID를 입력해주세요."; return }
-        feedIDText = ""
+        commentFeedIDText = ""
         commentIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
-            try await repository.reportSpoilerComment(feedID: feedID, commentID: commentID)
-            log = "댓글 스포일러 신고 성공 (feedID: \(feedID.value), commentID: \(commentID.value))"
+            try await repository.reportSpoilerComment(feedID: commentFeedID, commentID: commentID)
+            log = "댓글 스포일러 신고 성공 (feedID: \(commentFeedID.value), commentID: \(commentID.value))"
         } catch {
             log = "댓글 스포일러 신고 실패\n\(error)"
         }
     }
 
     private func reportImproperComment() async {
-        guard let feedID else { log = "피드 ID를 입력해주세요."; return }
+        guard let commentFeedID else { log = "피드 ID를 입력해주세요."; return }
         guard let commentID else { log = "댓글 ID를 입력해주세요."; return }
-        feedIDText = ""
+        commentFeedIDText = ""
         commentIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
-            try await repository.reportImproperComment(feedID: feedID, commentID: commentID)
-            log = "댓글 부적절 신고 성공 (feedID: \(feedID.value), commentID: \(commentID.value))"
+            try await repository.reportImproperComment(feedID: commentFeedID, commentID: commentID)
+            log = "댓글 부적절 신고 성공 (feedID: \(commentFeedID.value), commentID: \(commentID.value))"
         } catch {
             log = "댓글 부적절 신고 실패\n\(error)"
         }

--- a/Projects/Data/SocialData/Demo/SocialDataDemoView.swift
+++ b/Projects/Data/SocialData/Demo/SocialDataDemoView.swift
@@ -52,24 +52,31 @@ struct SocialDataDemoView: View {
             Text("Block").font(.headline).padding(.horizontal)
 
             HStack {
-                TextField("유저 ID", text: $userIDText)
+                TextField("차단할 유저 ID", text: $userIDText)
                     .textFieldStyle(.roundedBorder)
                     .keyboardType(.numberPad)
-                TextField("차단 ID", text: $blockIDText)
-                    .textFieldStyle(.roundedBorder)
-                    .keyboardType(.numberPad)
+                demoButton("차단", bg: Color(red: 1.0, green: 0.92, blue: 0.92), fg: .red) {
+                    Task { await blockUser() }
+                }
             }
             .padding(.horizontal)
 
-            HStack(spacing: 8) {
-                Button("차단") { Task { await blockUser() } }
-                Button("해제") { Task { await unblockUser() } }
-                Button("목록 조회") { Task { await loadBlockedUsers() } }
+            HStack {
+                TextField("해제할 차단 ID (목록의 [ ] 값)", text: $blockIDText)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.numberPad)
+                demoButton("해제", bg: Color(red: 0.88, green: 0.97, blue: 0.94), fg: .teal) {
+                    Task { await unblockUser() }
+                }
             }
-            .buttonStyle(.borderedProminent)
-            .disabled(isLoading)
+            .padding(.horizontal)
+
+            demoButton("목록 조회", bg: Color(red: 0.92, green: 0.90, blue: 0.99), fg: .indigo) {
+                Task { await loadBlockedUsers() }
+            }
             .padding(.horizontal)
         }
+        .disabled(isLoading)
     }
 
     private var reportFeedSection: some View {
@@ -82,10 +89,13 @@ struct SocialDataDemoView: View {
                 .padding(.horizontal)
 
             HStack(spacing: 8) {
-                Button("스포일러 신고") { Task { await reportSpoilerFeed() } }
-                Button("부적절 신고") { Task { await reportImproperFeed() } }
+                demoButton("스포일러 신고", bg: Color(red: 1.0, green: 0.94, blue: 0.88), fg: .orange) {
+                    Task { await reportSpoilerFeed() }
+                }
+                demoButton("부적절 신고", bg: Color(red: 0.99, green: 0.90, blue: 0.95), fg: .pink) {
+                    Task { await reportImproperFeed() }
+                }
             }
-            .buttonStyle(.borderedProminent)
             .disabled(isLoading)
             .padding(.horizontal)
         }
@@ -106,13 +116,34 @@ struct SocialDataDemoView: View {
             .padding(.horizontal)
 
             HStack(spacing: 8) {
-                Button("스포일러 신고") { Task { await reportSpoilerComment() } }
-                Button("부적절 신고") { Task { await reportImproperComment() } }
+                demoButton("스포일러 신고", bg: Color(red: 1.0, green: 0.94, blue: 0.88), fg: .orange) {
+                    Task { await reportSpoilerComment() }
+                }
+                demoButton("부적절 신고", bg: Color(red: 0.99, green: 0.90, blue: 0.95), fg: .pink) {
+                    Task { await reportImproperComment() }
+                }
             }
-            .buttonStyle(.borderedProminent)
             .disabled(isLoading)
             .padding(.horizontal)
         }
+    }
+
+    private func demoButton(
+        _ title: String,
+        bg: Color,
+        fg: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .foregroundColor(fg)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(bg)
+                .cornerRadius(10)
+        }
+        .buttonStyle(.plain)
     }
 
     private var logSection: some View {
@@ -154,6 +185,7 @@ struct SocialDataDemoView: View {
 
     private func blockUser() async {
         guard let userID else { log = "유저 ID를 입력해주세요."; return }
+        userIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
             try await repository.blockUser(id: userID)
@@ -165,6 +197,7 @@ struct SocialDataDemoView: View {
 
     private func unblockUser() async {
         guard let blockID else { log = "차단 ID를 입력해주세요."; return }
+        blockIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
             try await repository.unblockUser(id: blockID)
@@ -186,6 +219,7 @@ struct SocialDataDemoView: View {
 
     private func reportSpoilerFeed() async {
         guard let feedID else { log = "피드 ID를 입력해주세요."; return }
+        feedIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
             try await repository.reportSpoilerFeed(id: feedID)
@@ -197,6 +231,7 @@ struct SocialDataDemoView: View {
 
     private func reportImproperFeed() async {
         guard let feedID else { log = "피드 ID를 입력해주세요."; return }
+        feedIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
             try await repository.reportImproperFeed(id: feedID)
@@ -209,6 +244,8 @@ struct SocialDataDemoView: View {
     private func reportSpoilerComment() async {
         guard let feedID else { log = "피드 ID를 입력해주세요."; return }
         guard let commentID else { log = "댓글 ID를 입력해주세요."; return }
+        feedIDText = ""
+        commentIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
             try await repository.reportSpoilerComment(feedID: feedID, commentID: commentID)
@@ -221,6 +258,8 @@ struct SocialDataDemoView: View {
     private func reportImproperComment() async {
         guard let feedID else { log = "피드 ID를 입력해주세요."; return }
         guard let commentID else { log = "댓글 ID를 입력해주세요."; return }
+        feedIDText = ""
+        commentIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
             try await repository.reportImproperComment(feedID: feedID, commentID: commentID)

--- a/Projects/Data/SocialData/Demo/SocialDataDemoView.swift
+++ b/Projects/Data/SocialData/Demo/SocialDataDemoView.swift
@@ -1,0 +1,243 @@
+//
+//  SocialDataDemoView.swift
+//  SocialDataDemo
+//
+//  Created by WonsunLee on 5/1/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import SwiftUI
+
+import SocialData
+import SocialDomain
+import BaseDomain
+import Networking
+
+struct SocialDataDemoView: View {
+    @State private var log: String = "버튼을 눌러 API를 호출하세요."
+    @State private var userIDText: String = ""
+    @State private var blockIDText: String = ""
+    @State private var feedIDText: String = ""
+    @State private var commentIDText: String = ""
+    @State private var isLoading: Bool = false
+
+    private let repository: SocialRepository
+
+    init() {
+        let client = NetworkingClient()
+        self.repository = SocialDataFactory.makeSocialRepository(client: client)
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 16) {
+                    blockSection
+                    Divider()
+                    reportFeedSection
+                    Divider()
+                    reportCommentSection
+                    logSection
+                }
+                .padding(.vertical)
+            }
+            .navigationTitle("Social Demo")
+        }
+    }
+
+    // MARK: - Sections
+
+    private var blockSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Block").font(.headline).padding(.horizontal)
+
+            HStack {
+                TextField("유저 ID", text: $userIDText)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.numberPad)
+                TextField("차단 ID", text: $blockIDText)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.numberPad)
+            }
+            .padding(.horizontal)
+
+            HStack(spacing: 8) {
+                Button("차단") { Task { await blockUser() } }
+                Button("해제") { Task { await unblockUser() } }
+                Button("목록 조회") { Task { await loadBlockedUsers() } }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isLoading)
+            .padding(.horizontal)
+        }
+    }
+
+    private var reportFeedSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Report Feed").font(.headline).padding(.horizontal)
+
+            TextField("피드 ID", text: $feedIDText)
+                .textFieldStyle(.roundedBorder)
+                .keyboardType(.numberPad)
+                .padding(.horizontal)
+
+            HStack(spacing: 8) {
+                Button("스포일러 신고") { Task { await reportSpoilerFeed() } }
+                Button("부적절 신고") { Task { await reportImproperFeed() } }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isLoading)
+            .padding(.horizontal)
+        }
+    }
+
+    private var reportCommentSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Report Comment").font(.headline).padding(.horizontal)
+
+            HStack {
+                TextField("피드 ID", text: $feedIDText)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.numberPad)
+                TextField("댓글 ID", text: $commentIDText)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.numberPad)
+            }
+            .padding(.horizontal)
+
+            HStack(spacing: 8) {
+                Button("스포일러 신고") { Task { await reportSpoilerComment() } }
+                Button("부적절 신고") { Task { await reportImproperComment() } }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isLoading)
+            .padding(.horizontal)
+        }
+    }
+
+    private var logSection: some View {
+        ScrollView {
+            Text(log)
+                .font(.system(size: 13, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+        .frame(height: 200)
+        .background(Color(.systemGray6))
+        .cornerRadius(8)
+        .padding(.horizontal)
+    }
+
+    // MARK: - Computed IDs
+
+    private var userID: UserID? {
+        guard let value = Int(userIDText) else { return nil }
+        return UserID(value)
+    }
+
+    private var blockID: BlockID? {
+        guard let value = Int(blockIDText) else { return nil }
+        return BlockID(value)
+    }
+
+    private var feedID: FeedID? {
+        guard let value = Int(feedIDText) else { return nil }
+        return FeedID(value)
+    }
+
+    private var commentID: CommentID? {
+        guard let value = Int(commentIDText) else { return nil }
+        return CommentID(value)
+    }
+
+    // MARK: - Actions
+
+    private func blockUser() async {
+        guard let userID else { log = "유저 ID를 입력해주세요."; return }
+        isLoading = true; defer { isLoading = false }
+        do {
+            try await repository.blockUser(id: userID)
+            log = "차단 성공 (userID: \(userID.value))"
+        } catch {
+            log = "차단 실패\n\(error)"
+        }
+    }
+
+    private func unblockUser() async {
+        guard let blockID else { log = "차단 ID를 입력해주세요."; return }
+        isLoading = true; defer { isLoading = false }
+        do {
+            try await repository.unblockUser(id: blockID)
+            log = "차단 해제 성공 (blockID: \(blockID.value))"
+        } catch {
+            log = "차단 해제 실패\n\(error)"
+        }
+    }
+
+    private func loadBlockedUsers() async {
+        isLoading = true; defer { isLoading = false }
+        do {
+            let users = try await repository.loadBlockedUsers()
+            log = formatBlockedUsers(users)
+        } catch {
+            log = "차단 목록 조회 실패\n\(error)"
+        }
+    }
+
+    private func reportSpoilerFeed() async {
+        guard let feedID else { log = "피드 ID를 입력해주세요."; return }
+        isLoading = true; defer { isLoading = false }
+        do {
+            try await repository.reportSpoilerFeed(id: feedID)
+            log = "피드 스포일러 신고 성공 (feedID: \(feedID.value))"
+        } catch {
+            log = "피드 스포일러 신고 실패\n\(error)"
+        }
+    }
+
+    private func reportImproperFeed() async {
+        guard let feedID else { log = "피드 ID를 입력해주세요."; return }
+        isLoading = true; defer { isLoading = false }
+        do {
+            try await repository.reportImproperFeed(id: feedID)
+            log = "피드 부적절 신고 성공 (feedID: \(feedID.value))"
+        } catch {
+            log = "피드 부적절 신고 실패\n\(error)"
+        }
+    }
+
+    private func reportSpoilerComment() async {
+        guard let feedID else { log = "피드 ID를 입력해주세요."; return }
+        guard let commentID else { log = "댓글 ID를 입력해주세요."; return }
+        isLoading = true; defer { isLoading = false }
+        do {
+            try await repository.reportSpoilerComment(feedID: feedID, commentID: commentID)
+            log = "댓글 스포일러 신고 성공 (feedID: \(feedID.value), commentID: \(commentID.value))"
+        } catch {
+            log = "댓글 스포일러 신고 실패\n\(error)"
+        }
+    }
+
+    private func reportImproperComment() async {
+        guard let feedID else { log = "피드 ID를 입력해주세요."; return }
+        guard let commentID else { log = "댓글 ID를 입력해주세요."; return }
+        isLoading = true; defer { isLoading = false }
+        do {
+            try await repository.reportImproperComment(feedID: feedID, commentID: commentID)
+            log = "댓글 부적절 신고 성공 (feedID: \(feedID.value), commentID: \(commentID.value))"
+        } catch {
+            log = "댓글 부적절 신고 실패\n\(error)"
+        }
+    }
+
+    // MARK: - Formatters
+
+    private func formatBlockedUsers(_ users: [BlockedUser]) -> String {
+        if users.isEmpty { return "차단 목록 없음" }
+        var text = "차단 유저 \(users.count)명\n\n"
+        for user in users {
+            text += "[\(user.blockID.value)] \(user.nickname) (userID: \(user.userID.value))\n"
+        }
+        return text
+    }
+}

--- a/Projects/Data/SocialData/Project.swift
+++ b/Projects/Data/SocialData/Project.swift
@@ -11,7 +11,7 @@ import DependencyPlugin
 
 let project = Project.createDataModule(
     name: ModuleType.data(.social).name,
-    targets: [.sources, .testing, .tests],
+    targets: [.sources, .demo, .testing, .tests],
     internalDependencies: [
         .module(.core(.networking)),
         .module(.core(.logger)),

--- a/Projects/Data/SocialData/Project.swift
+++ b/Projects/Data/SocialData/Project.swift
@@ -1,0 +1,22 @@
+//
+//  Project.swift
+//  AppManifests
+//
+//  Created by WonsunLee on 4/25/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.createDataModule(
+    name: ModuleType.data(.social).name,
+    targets: [.sources, .testing, .tests],
+    internalDependencies: [
+        .module(.core(.networking)),
+        .module(.core(.logger)),
+        .module(.domain(.social)),
+        .module(.domain(.base)),
+        .module(.data(.base))
+    ]
+)

--- a/Projects/Data/SocialData/Sources/DTO/Response/BlockedUserResponse.swift
+++ b/Projects/Data/SocialData/Sources/DTO/Response/BlockedUserResponse.swift
@@ -1,0 +1,18 @@
+//
+//  BlockedUserResponse.swift
+//  SocialData
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+struct BlockedUserResponse: Decodable {
+    let blocks: [BlockdUser]
+}
+
+struct BlockdUser: Decodable {
+    let blockId: Int
+    let userId: Int
+    let nickname: String
+    let avatarImage: String
+}

--- a/Projects/Data/SocialData/Sources/Endpoint/SocialEndpoint.swift
+++ b/Projects/Data/SocialData/Sources/Endpoint/SocialEndpoint.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Networking
+import BaseData
 
 enum SocialEndpoint: Endpoint {
 
@@ -32,8 +33,7 @@ enum SocialEndpoint: Endpoint {
     }
 
     var baseURL: URL {
-        // TODO: 컨피그 설정 후 baseURL 반영
-        URL(string: "")!
+        URL(string: NetworkingConfig.baseURL) ?? URL(string: "")!
     }
 
     var path: String {
@@ -66,7 +66,7 @@ enum SocialEndpoint: Endpoint {
 
     var headers: [String: String]? {
         ["Content-Type": "application/json",
-         "Authorization": "Bearer " + "dummyAccessToken"]
+         "Authorization": "Bearer " + "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhY2Nlc3MiLCJpYXQiOjE3Nzc2MzAxNTQsImV4cCI6MTc3NzYzMTk1NCwidXNlcklkIjoxMDAzM30.tbEdBMlL9k1EAxnmHJfjG_v1EcwVrXQRn8jDOA2kW2M"]
     }
 
     var body: Data? { nil }

--- a/Projects/Data/SocialData/Sources/Endpoint/SocialEndpoint.swift
+++ b/Projects/Data/SocialData/Sources/Endpoint/SocialEndpoint.swift
@@ -13,7 +13,7 @@ import BaseData
 enum SocialEndpoint: Endpoint {
 
     case blockUser(userID: Int)
-    case unblockUser(userID: Int)
+    case unblockUser(blockId: Int)
     case getBlockedUsers
     case reportSpoilerFeed(feedID: Int)
     case reportImproperFeed(feedID: Int)
@@ -40,8 +40,8 @@ enum SocialEndpoint: Endpoint {
         switch self {
         case .blockUser:
             return "/blocks"
-        case .unblockUser(let userID):
-            return "/blocks/\(userID)"
+        case .unblockUser(let blockId):
+            return "/blocks/\(blockId)"
         case .getBlockedUsers:
             return "/blocks"
         case .reportSpoilerFeed(let feedID):
@@ -66,7 +66,7 @@ enum SocialEndpoint: Endpoint {
 
     var headers: [String: String]? {
         ["Content-Type": "application/json",
-         "Authorization": "Bearer " + "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhY2Nlc3MiLCJpYXQiOjE3Nzc2MzAxNTQsImV4cCI6MTc3NzYzMTk1NCwidXNlcklkIjoxMDAzM30.tbEdBMlL9k1EAxnmHJfjG_v1EcwVrXQRn8jDOA2kW2M"]
+         "Authorization": "Bearer " + "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhY2Nlc3MiLCJpYXQiOjE3Nzc2MzE5ODUsImV4cCI6MTc3NzYzMzc4NSwidXNlcklkIjoxMDAzM30.shLM9DXSzNvP6YO5WDDQ3WLqnfiCi-M6htmJ2Zi_u6g"]
     }
 
     var body: Data? { nil }

--- a/Projects/Data/SocialData/Sources/Endpoint/SocialEndpoint.swift
+++ b/Projects/Data/SocialData/Sources/Endpoint/SocialEndpoint.swift
@@ -9,8 +9,6 @@
 import Foundation
 import Networking
 
-// TODO: Domain에 엔드포인트 맞춰서 feedID 추가해둠 말해주기
-
 enum SocialEndpoint: Endpoint {
 
     case blockUser(userID: Int)

--- a/Projects/Data/SocialData/Sources/Endpoint/SocialEndpoint.swift
+++ b/Projects/Data/SocialData/Sources/Endpoint/SocialEndpoint.swift
@@ -1,0 +1,77 @@
+//
+//  SocialEndpoint.swift
+//  SocialData
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import Networking
+
+// TODO: Domain에 엔드포인트 맞춰서 feedID 추가해둠 말해주기
+
+enum SocialEndpoint: Endpoint {
+
+    case blockUser(userID: Int)
+    case unblockUser(userID: Int)
+    case getBlockedUsers
+    case reportSpoilerFeed(feedID: Int)
+    case reportImproperFeed(feedID: Int)
+    case reportSpoilerComment(feedID: Int, commentID: Int)
+    case reportImproperComment(feedID: Int, commentID: Int)
+
+    var method: HTTPMethod {
+        switch self {
+        case .blockUser:             return .post
+        case .unblockUser:           return .delete
+        case .getBlockedUsers:       return .get
+        case .reportSpoilerFeed:     return .post
+        case .reportImproperFeed:    return .post
+        case .reportSpoilerComment:  return .post
+        case .reportImproperComment: return .post
+        }
+    }
+
+    var baseURL: URL {
+        // TODO: 컨피그 설정 후 baseURL 반영
+        URL(string: "")!
+    }
+
+    var path: String {
+        switch self {
+        case .blockUser:
+            return "/blocks"
+        case .unblockUser(let userID):
+            return "/blocks/\(userID)"
+        case .getBlockedUsers:
+            return "/blocks"
+        case .reportSpoilerFeed(let feedID):
+            return "/feeds/\(feedID)/spoiler"
+        case .reportImproperFeed(let feedID):
+            return "/feeds/\(feedID)/impertinence"
+        case .reportSpoilerComment(let feedID, let commentID):
+            return "/feeds/\(feedID)/comments/\(commentID)/spoiler"
+        case .reportImproperComment(let feedID, let commentID):
+            return "/feeds/\(feedID)/comments/\(commentID)/impertinence"
+        }
+    }
+
+    var queryItems: [URLQueryItem]? {
+        switch self {
+        case .blockUser(let userID):
+            return [URLQueryItem(name: "userId", value: String(userID))]
+        default:
+            return nil
+        }
+    }
+
+    var headers: [String: String]? {
+        ["Content-Type": "application/json",
+         "Authorization": "Bearer " + "dummyAccessToken"]
+    }
+
+    var body: Data? { nil }
+
+    var requireTokenRefresh: Bool { true }
+}

--- a/Projects/Data/SocialData/Sources/Factory/SocialDataFactory.swift
+++ b/Projects/Data/SocialData/Sources/Factory/SocialDataFactory.swift
@@ -1,0 +1,24 @@
+//
+//  SocialDataFactory.swift
+//  SocialData
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Networking
+import SocialDomain
+import BaseData
+import Logger
+
+public enum SocialDataFactory {
+
+    public static func makeSocialRepository(
+        client: NetworkingRequestable,
+        underlying: Logger? = nil
+    ) -> SocialRepository {
+        let service = DefaultSocialService(client: client)
+        let logger = DataLogger(moduleName: "SocialData", underlying: underlying)
+        return DefaultSocialRepository(service: service, logger: logger)
+    }
+}

--- a/Projects/Data/SocialData/Sources/Logger/SocialAction.swift
+++ b/Projects/Data/SocialData/Sources/Logger/SocialAction.swift
@@ -1,0 +1,21 @@
+//
+//  SocialAction.swift
+//  SocialData
+//
+//  Created by Lee Wonsun on 4/26/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+enum SocialAction: String {
+    case blockUser
+    case unblockUser
+    case loadBlockedUsers
+    case reportSpoilerFeed
+    case reportImproperFeed
+    case reportSpoilerComment
+    case reportImproperComment
+    
+    var name: String { return self.rawValue }
+}

--- a/Projects/Data/SocialData/Sources/Mapper/SocialMapper.swift
+++ b/Projects/Data/SocialData/Sources/Mapper/SocialMapper.swift
@@ -12,16 +12,16 @@ import BaseDomain
 
 enum SocialMapper {
 
-    static func blockedUser(from response: BlockedUserResponse) -> BlockedUser {
+    static func blockedUser(from response: BlockdUser) -> BlockedUser {
         BlockedUser(
             blockID: BlockID(response.blockId),
             userID: UserID(response.userId),
             nickname: response.nickname,
-            profileImageURL: response.profileImage.flatMap(URL.init)
+            profileImageURL: URL(string: response.avatarImage)
         )
     }
 
-    static func blockedUsers(from responses: [BlockedUserResponse]) -> [BlockedUser] {
-        responses.map { blockedUser(from: $0) }
+    static func blockedUsers(from response: BlockedUserResponse) -> [BlockedUser] {
+        response.blocks.map { blockedUser(from: $0) }
     }
 }

--- a/Projects/Data/SocialData/Sources/Mapper/SocialMapper.swift
+++ b/Projects/Data/SocialData/Sources/Mapper/SocialMapper.swift
@@ -1,0 +1,27 @@
+//
+//  SocialMapper.swift
+//  SocialData
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import SocialDomain
+import BaseDomain
+
+enum SocialMapper {
+
+    static func blockedUser(from response: BlockedUserResponse) -> BlockedUser {
+        BlockedUser(
+            blockID: BlockID(response.blockId),
+            userID: UserID(response.userId),
+            nickname: response.nickname,
+            profileImageURL: response.profileImage.flatMap(URL.init)
+        )
+    }
+
+    static func blockedUsers(from responses: [BlockedUserResponse]) -> [BlockedUser] {
+        responses.map { blockedUser(from: $0) }
+    }
+}

--- a/Projects/Data/SocialData/Sources/Repository/DefaultSocialRepository.swift
+++ b/Projects/Data/SocialData/Sources/Repository/DefaultSocialRepository.swift
@@ -29,6 +29,7 @@ public struct DefaultSocialRepository: SocialRepository {
         
         do {
             try await service.postBlockUser(userID: id.value)
+            logger.logSuccess(action: action.name)
         } catch let error as NetworkingError {
             logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
@@ -43,6 +44,7 @@ public struct DefaultSocialRepository: SocialRepository {
         
         do {
             try await service.deleteBlock(blockID: id.value)
+            logger.logSuccess(action: action.name)
         } catch let error as NetworkingError {
             logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
@@ -57,6 +59,7 @@ public struct DefaultSocialRepository: SocialRepository {
         
         do {
             let responses = try await service.getBlockedUsers()
+            logger.logSuccess(action: action.name)
             return SocialMapper.blockedUsers(from: responses)
         } catch let error as NetworkingError {
             logger.logNetworkError(action: action.name, error: error)
@@ -72,6 +75,7 @@ public struct DefaultSocialRepository: SocialRepository {
         
         do {
             try await service.postReportSpoilerFeed(feedID: id.value)
+            logger.logSuccess(action: action.name)
         } catch let error as NetworkingError {
             logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
@@ -86,6 +90,7 @@ public struct DefaultSocialRepository: SocialRepository {
         
         do {
             try await service.postReportImproperFeed(feedID: id.value)
+            logger.logSuccess(action: action.name)
         } catch let error as NetworkingError {
             logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
@@ -100,6 +105,7 @@ public struct DefaultSocialRepository: SocialRepository {
         
         do {
             try await service.postReportSpoilerComment(feedID: feedID.value, commentID: commentID.value)
+            logger.logSuccess(action: action.name)
         } catch let error as NetworkingError {
             logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
@@ -114,6 +120,7 @@ public struct DefaultSocialRepository: SocialRepository {
         
         do {
             try await service.postReportImproperComment(feedID: feedID.value, commentID: commentID.value)
+            logger.logSuccess(action: action.name)
         } catch let error as NetworkingError {
             logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()

--- a/Projects/Data/SocialData/Sources/Repository/DefaultSocialRepository.swift
+++ b/Projects/Data/SocialData/Sources/Repository/DefaultSocialRepository.swift
@@ -25,86 +25,100 @@ public struct DefaultSocialRepository: SocialRepository {
     }
 
     public func blockUser(id: UserID) async throws(RepositoryError) {
+        let action = SocialAction.blockUser
+        
         do {
             try await service.postBlockUser(userID: id.value)
         } catch let error as NetworkingError {
-            logger.logNetworkError(action: "blockUser", error: error)
+            logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
         } catch {
-            logger.logUnknownError(action: "blockUser", error: error)
+            logger.logUnknownError(action: action.name, error: error)
             throw .unknown
         }
     }
 
     public func unblockUser(id: BlockID) async throws(RepositoryError) {
+        let action = SocialAction.unblockUser
+        
         do {
             try await service.deleteBlock(blockID: id.value)
         } catch let error as NetworkingError {
-            logger.logNetworkError(action: "unblockUser", error: error)
+            logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
         } catch {
-            logger.logUnknownError(action: "unblockUser", error: error)
+            logger.logUnknownError(action: action.name, error: error)
             throw .unknown
         }
     }
 
     public func loadBlockedUsers() async throws(RepositoryError) -> [BlockedUser] {
+        let action = SocialAction.loadBlockedUsers
+        
         do {
             let responses = try await service.getBlockedUsers()
             return SocialMapper.blockedUsers(from: responses)
         } catch let error as NetworkingError {
-            logger.logNetworkError(action: "loadBlockedUsers", error: error)
+            logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
         } catch {
-            logger.logUnknownError(action: "loadBlockedUsers", error: error)
+            logger.logUnknownError(action: action.name, error: error)
             throw .unknown
         }
     }
 
     public func reportSpoilerFeed(id: FeedID) async throws(RepositoryError) {
+        let action = SocialAction.reportSpoilerFeed
+        
         do {
             try await service.postReportSpoilerFeed(feedID: id.value)
         } catch let error as NetworkingError {
-            logger.logNetworkError(action: "reportSpoilerFeed", error: error)
+            logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
         } catch {
-            logger.logUnknownError(action: "reportSpoilerFeed", error: error)
+            logger.logUnknownError(action: action.name, error: error)
             throw .unknown
         }
     }
 
     public func reportImproperFeed(id: FeedID) async throws(RepositoryError) {
+        let action = SocialAction.reportImproperFeed
+        
         do {
             try await service.postReportImproperFeed(feedID: id.value)
         } catch let error as NetworkingError {
-            logger.logNetworkError(action: "reportImproperFeed", error: error)
+            logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
         } catch {
-            logger.logUnknownError(action: "reportImproperFeed", error: error)
+            logger.logUnknownError(action: action.name, error: error)
             throw .unknown
         }
     }
 
     public func reportSpoilerComment(feedID: FeedID, commentID: CommentID) async throws(RepositoryError) {
+        let action = SocialAction.reportSpoilerComment
+        
         do {
             try await service.postReportSpoilerComment(feedID: feedID.value, commentID: commentID.value)
         } catch let error as NetworkingError {
-            logger.logNetworkError(action: "reportSpoilerComment", error: error)
+            logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
         } catch {
-            logger.logUnknownError(action: "reportSpoilerComment", error: error)
+            logger.logUnknownError(action: action.name, error: error)
             throw .unknown
         }
     }
 
     public func reportImproperComment(feedID: FeedID, commentID: CommentID) async throws(RepositoryError) {
+        let action = SocialAction.reportImproperComment
+        
         do {
             try await service.postReportImproperComment(feedID: feedID.value, commentID: commentID.value)
         } catch let error as NetworkingError {
-            logger.logNetworkError(action: "reportImproperComment", error: error)
+            logger.logNetworkError(action: action.name, error: error)
             throw error.toRepositoryError()
         } catch {
-            logger.logUnknownError(action: "reportImproperComment", error: error)
+            logger.logUnknownError(action: action.name, error: error)
             throw .unknown
         }
     }

--- a/Projects/Data/SocialData/Sources/Repository/DefaultSocialRepository.swift
+++ b/Projects/Data/SocialData/Sources/Repository/DefaultSocialRepository.swift
@@ -1,0 +1,111 @@
+//
+//  DefaultSocialRepository.swift
+//  SocialData
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import SocialDomain
+import BaseDomain
+import BaseData
+import Networking
+
+public struct DefaultSocialRepository: SocialRepository {
+    private let service: SocialService
+    private let logger: DataLogger
+
+    init(
+        service: SocialService,
+        logger: DataLogger
+    ) {
+        self.service = service
+        self.logger = logger
+    }
+
+    public func blockUser(id: UserID) async throws(RepositoryError) {
+        do {
+            try await service.postBlockUser(userID: id.value)
+        } catch let error as NetworkingError {
+            logger.logNetworkError(action: "blockUser", error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger.logUnknownError(action: "blockUser", error: error)
+            throw .unknown
+        }
+    }
+
+    public func unblockUser(id: BlockID) async throws(RepositoryError) {
+        do {
+            try await service.deleteBlock(blockID: id.value)
+        } catch let error as NetworkingError {
+            logger.logNetworkError(action: "unblockUser", error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger.logUnknownError(action: "unblockUser", error: error)
+            throw .unknown
+        }
+    }
+
+    public func loadBlockedUsers() async throws(RepositoryError) -> [BlockedUser] {
+        do {
+            let responses = try await service.getBlockedUsers()
+            return SocialMapper.blockedUsers(from: responses)
+        } catch let error as NetworkingError {
+            logger.logNetworkError(action: "loadBlockedUsers", error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger.logUnknownError(action: "loadBlockedUsers", error: error)
+            throw .unknown
+        }
+    }
+
+    public func reportSpoilerFeed(id: FeedID) async throws(RepositoryError) {
+        do {
+            try await service.postReportSpoilerFeed(feedID: id.value)
+        } catch let error as NetworkingError {
+            logger.logNetworkError(action: "reportSpoilerFeed", error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger.logUnknownError(action: "reportSpoilerFeed", error: error)
+            throw .unknown
+        }
+    }
+
+    public func reportImproperFeed(id: FeedID) async throws(RepositoryError) {
+        do {
+            try await service.postReportImproperFeed(feedID: id.value)
+        } catch let error as NetworkingError {
+            logger.logNetworkError(action: "reportImproperFeed", error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger.logUnknownError(action: "reportImproperFeed", error: error)
+            throw .unknown
+        }
+    }
+
+    public func reportSpoilerComment(feedID: FeedID, commentID: CommentID) async throws(RepositoryError) {
+        do {
+            try await service.postReportSpoilerComment(feedID: feedID.value, commentID: commentID.value)
+        } catch let error as NetworkingError {
+            logger.logNetworkError(action: "reportSpoilerComment", error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger.logUnknownError(action: "reportSpoilerComment", error: error)
+            throw .unknown
+        }
+    }
+
+    public func reportImproperComment(feedID: FeedID, commentID: CommentID) async throws(RepositoryError) {
+        do {
+            try await service.postReportImproperComment(feedID: feedID.value, commentID: commentID.value)
+        } catch let error as NetworkingError {
+            logger.logNetworkError(action: "reportImproperComment", error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger.logUnknownError(action: "reportImproperComment", error: error)
+            throw .unknown
+        }
+    }
+}

--- a/Projects/Data/SocialData/Sources/Service/DefaultSocialService.swift
+++ b/Projects/Data/SocialData/Sources/Service/DefaultSocialService.swift
@@ -1,0 +1,53 @@
+//
+//  DefaultSocialService.swift
+//  SocialData
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import Networking
+
+struct DefaultSocialService: SocialService {
+    private let client: NetworkingRequestable
+
+    init(client: NetworkingRequestable) {
+        self.client = client
+    }
+
+    func postBlockUser(userID: Int) async throws {
+        let endpoint = SocialEndpoint.blockUser(userID: userID)
+        _ = try await client.request(endpoint)
+    }
+
+    func deleteBlock(blockID: Int) async throws {
+        let endpoint = SocialEndpoint.unblockUser(userID: blockID)
+        _ = try await client.request(endpoint)
+    }
+
+    func getBlockedUsers() async throws -> [BlockedUserResponse] {
+        let endpoint = SocialEndpoint.getBlockedUsers
+        return try await client.request(endpoint, decodeTo: [BlockedUserResponse].self)
+    }
+
+    func postReportSpoilerFeed(feedID: Int) async throws {
+        let endpoint = SocialEndpoint.reportSpoilerFeed(feedID: feedID)
+        _ = try await client.request(endpoint)
+    }
+
+    func postReportImproperFeed(feedID: Int) async throws {
+        let endpoint = SocialEndpoint.reportImproperFeed(feedID: feedID)
+        _ = try await client.request(endpoint)
+    }
+
+    func postReportSpoilerComment(feedID: Int, commentID: Int) async throws {
+        let endpoint = SocialEndpoint.reportSpoilerComment(feedID: feedID, commentID: commentID)
+        _ = try await client.request(endpoint)
+    }
+
+    func postReportImproperComment(feedID: Int, commentID: Int) async throws {
+        let endpoint = SocialEndpoint.reportImproperComment(feedID: feedID, commentID: commentID)
+        _ = try await client.request(endpoint)
+    }
+}

--- a/Projects/Data/SocialData/Sources/Service/DefaultSocialService.swift
+++ b/Projects/Data/SocialData/Sources/Service/DefaultSocialService.swift
@@ -26,9 +26,9 @@ struct DefaultSocialService: SocialService {
         _ = try await client.request(endpoint)
     }
 
-    func getBlockedUsers() async throws -> [BlockedUserResponse] {
+    func getBlockedUsers() async throws -> BlockedUserResponse {
         let endpoint = SocialEndpoint.getBlockedUsers
-        return try await client.request(endpoint, decodeTo: [BlockedUserResponse].self)
+        return try await client.request(endpoint, decodeTo: BlockedUserResponse.self)
     }
 
     func postReportSpoilerFeed(feedID: Int) async throws {

--- a/Projects/Data/SocialData/Sources/Service/DefaultSocialService.swift
+++ b/Projects/Data/SocialData/Sources/Service/DefaultSocialService.swift
@@ -22,7 +22,7 @@ struct DefaultSocialService: SocialService {
     }
 
     func deleteBlock(blockID: Int) async throws {
-        let endpoint = SocialEndpoint.unblockUser(userID: blockID)
+        let endpoint = SocialEndpoint.unblockUser(blockId: blockID)
         _ = try await client.request(endpoint)
     }
 

--- a/Projects/Data/SocialData/Sources/Service/SocialService.swift
+++ b/Projects/Data/SocialData/Sources/Service/SocialService.swift
@@ -9,7 +9,7 @@
 protocol SocialService {
     func postBlockUser(userID: Int) async throws
     func deleteBlock(blockID: Int) async throws
-    func getBlockedUsers() async throws -> [BlockedUserResponse]
+    func getBlockedUsers() async throws -> BlockedUserResponse
     func postReportSpoilerFeed(feedID: Int) async throws
     func postReportImproperFeed(feedID: Int) async throws
     func postReportSpoilerComment(feedID: Int, commentID: Int) async throws

--- a/Projects/Data/SocialData/Sources/Service/SocialService.swift
+++ b/Projects/Data/SocialData/Sources/Service/SocialService.swift
@@ -1,0 +1,17 @@
+//
+//  SocialService.swift
+//  SocialData
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+protocol SocialService {
+    func postBlockUser(userID: Int) async throws
+    func deleteBlock(blockID: Int) async throws
+    func getBlockedUsers() async throws -> [BlockedUserResponse]
+    func postReportSpoilerFeed(feedID: Int) async throws
+    func postReportImproperFeed(feedID: Int) async throws
+    func postReportSpoilerComment(feedID: Int, commentID: Int) async throws
+    func postReportImproperComment(feedID: Int, commentID: Int) async throws
+}

--- a/Projects/Data/SocialData/Sources/SocialData.swift
+++ b/Projects/Data/SocialData/Sources/SocialData.swift
@@ -1,0 +1,7 @@
+//
+//  SocialData.swift
+//  SocialData
+//
+//  Created by WonsunLee on 4/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//

--- a/Projects/Data/SocialData/Sources/SocialData.swift
+++ b/Projects/Data/SocialData/Sources/SocialData.swift
@@ -1,7 +1,0 @@
-//
-//  SocialData.swift
-//  SocialData
-//
-//  Created by WonsunLee on 4/25/26.
-//  Copyright © 2026 kr.websoso.app. All rights reserved.
-//

--- a/Projects/Data/SocialData/Testing/MockError.swift
+++ b/Projects/Data/SocialData/Testing/MockError.swift
@@ -1,0 +1,11 @@
+//
+//  MockError.swift
+//  SocialDataTesting
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+enum MockError: Error {
+    case stub
+}

--- a/Projects/Data/SocialData/Testing/MockSocialLogger.swift
+++ b/Projects/Data/SocialData/Testing/MockSocialLogger.swift
@@ -1,30 +1,8 @@
 //
-//  MockSocialLogger.swift
-//  SocialDataTesting
+//  SocialDataTesting.swift
+//  AppManifests
 //
 //  Created by YunhakLee on 4/23/26.
-//  Copyright © 2026 kr.websoso.app. All rights reserved.
 //
 
-@testable import SocialData
-
-public final class MockSocialLogger: SocialLogger {
-
-    public private(set) var logErrorCallCount = 0
-    public private(set) var loggedTypes: [SocialErrorType] = []
-    public private(set) var loggedActions: [SocialAction] = []
-    public private(set) var loggedErrors: [Error?] = []
-
-    public init() {}
-
-    public func logError(
-        type: SocialErrorType,
-        action: SocialAction,
-        error: Error?
-    ) {
-        logErrorCallCount += 1
-        loggedTypes.append(type)
-        loggedActions.append(action)
-        loggedErrors.append(error)
-    }
-}
+import Foundation

--- a/Projects/Data/SocialData/Testing/MockSocialLogger.swift
+++ b/Projects/Data/SocialData/Testing/MockSocialLogger.swift
@@ -1,0 +1,30 @@
+//
+//  MockSocialLogger.swift
+//  SocialDataTesting
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+@testable import SocialData
+
+public final class MockSocialLogger: SocialLogger {
+
+    public private(set) var logErrorCallCount = 0
+    public private(set) var loggedTypes: [SocialErrorType] = []
+    public private(set) var loggedActions: [SocialAction] = []
+    public private(set) var loggedErrors: [Error?] = []
+
+    public init() {}
+
+    public func logError(
+        type: SocialErrorType,
+        action: SocialAction,
+        error: Error?
+    ) {
+        logErrorCallCount += 1
+        loggedTypes.append(type)
+        loggedActions.append(action)
+        loggedErrors.append(error)
+    }
+}

--- a/Projects/Data/SocialData/Testing/MockSocialService.swift
+++ b/Projects/Data/SocialData/Testing/MockSocialService.swift
@@ -23,8 +23,10 @@ final class MockSocialService: SocialService {
     private(set) var postReportImproperFeedCallCount = 0
     private(set) var reportedImproperFeedIDs: [Int] = []
     private(set) var postReportSpoilerCommentCallCount = 0
+    private(set) var reportedSpoilerCommentFeedIDs: [Int] = []
     private(set) var reportedSpoilerCommentIDs: [Int] = []
     private(set) var postReportImproperCommentCallCount = 0
+    private(set) var reportedImproperCommentFeedIDs: [Int] = []
     private(set) var reportedImproperCommentIDs: [Int] = []
 
     // MARK: - Results
@@ -68,14 +70,16 @@ final class MockSocialService: SocialService {
         try postReportImproperFeedResult.get()
     }
 
-    func postReportSpoilerComment(commentID: Int) async throws {
+    func postReportSpoilerComment(feedID: Int, commentID: Int) async throws {
         postReportSpoilerCommentCallCount += 1
+        reportedSpoilerCommentFeedIDs.append(feedID)
         reportedSpoilerCommentIDs.append(commentID)
         try postReportSpoilerCommentResult.get()
     }
 
-    func postReportImproperComment(commentID: Int) async throws {
+    func postReportImproperComment(feedID: Int, commentID: Int) async throws {
         postReportImproperCommentCallCount += 1
+        reportedImproperCommentFeedIDs.append(feedID)
         reportedImproperCommentIDs.append(commentID)
         try postReportImproperCommentResult.get()
     }

--- a/Projects/Data/SocialData/Testing/MockSocialService.swift
+++ b/Projects/Data/SocialData/Testing/MockSocialService.swift
@@ -1,0 +1,82 @@
+//
+//  MockSocialService.swift
+//  SocialDataTesting
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+@testable import SocialData
+
+final class MockSocialService: SocialService {
+
+    // MARK: - Call tracking
+
+    private(set) var postBlockUserCallCount = 0
+    private(set) var blockedUserIDs: [Int] = []
+    private(set) var deleteBlockCallCount = 0
+    private(set) var deletedBlockIDs: [Int] = []
+    private(set) var getBlockedUsersCallCount = 0
+    private(set) var postReportSpoilerFeedCallCount = 0
+    private(set) var reportedSpoilerFeedIDs: [Int] = []
+    private(set) var postReportImproperFeedCallCount = 0
+    private(set) var reportedImproperFeedIDs: [Int] = []
+    private(set) var postReportSpoilerCommentCallCount = 0
+    private(set) var reportedSpoilerCommentIDs: [Int] = []
+    private(set) var postReportImproperCommentCallCount = 0
+    private(set) var reportedImproperCommentIDs: [Int] = []
+
+    // MARK: - Results
+
+    var postBlockUserResult: Result<Void, Error> = .success(())
+    var deleteBlockResult: Result<Void, Error> = .success(())
+    var getBlockedUsersResult: Result<[BlockedUserResponse], Error> = .success([])
+    var postReportSpoilerFeedResult: Result<Void, Error> = .success(())
+    var postReportImproperFeedResult: Result<Void, Error> = .success(())
+    var postReportSpoilerCommentResult: Result<Void, Error> = .success(())
+    var postReportImproperCommentResult: Result<Void, Error> = .success(())
+
+    // MARK: - SocialService
+
+    func postBlockUser(userID: Int) async throws {
+        postBlockUserCallCount += 1
+        blockedUserIDs.append(userID)
+        try postBlockUserResult.get()
+    }
+
+    func deleteBlock(blockID: Int) async throws {
+        deleteBlockCallCount += 1
+        deletedBlockIDs.append(blockID)
+        try deleteBlockResult.get()
+    }
+
+    func getBlockedUsers() async throws -> [BlockedUserResponse] {
+        getBlockedUsersCallCount += 1
+        return try getBlockedUsersResult.get()
+    }
+
+    func postReportSpoilerFeed(feedID: Int) async throws {
+        postReportSpoilerFeedCallCount += 1
+        reportedSpoilerFeedIDs.append(feedID)
+        try postReportSpoilerFeedResult.get()
+    }
+
+    func postReportImproperFeed(feedID: Int) async throws {
+        postReportImproperFeedCallCount += 1
+        reportedImproperFeedIDs.append(feedID)
+        try postReportImproperFeedResult.get()
+    }
+
+    func postReportSpoilerComment(commentID: Int) async throws {
+        postReportSpoilerCommentCallCount += 1
+        reportedSpoilerCommentIDs.append(commentID)
+        try postReportSpoilerCommentResult.get()
+    }
+
+    func postReportImproperComment(commentID: Int) async throws {
+        postReportImproperCommentCallCount += 1
+        reportedImproperCommentIDs.append(commentID)
+        try postReportImproperCommentResult.get()
+    }
+}

--- a/Projects/Data/SocialData/Testing/MockSocialService.swift
+++ b/Projects/Data/SocialData/Testing/MockSocialService.swift
@@ -31,7 +31,7 @@ final class MockSocialService: SocialService {
 
     var postBlockUserResult: Result<Void, Error> = .success(())
     var deleteBlockResult: Result<Void, Error> = .success(())
-    var getBlockedUsersResult: Result<[BlockedUserResponse], Error> = .success([])
+    var getBlockedUsersResult: Result<BlockedUserResponse, Error> = .success(BlockedUserResponse(blocks: []))
     var postReportSpoilerFeedResult: Result<Void, Error> = .success(())
     var postReportImproperFeedResult: Result<Void, Error> = .success(())
     var postReportSpoilerCommentResult: Result<Void, Error> = .success(())
@@ -51,7 +51,7 @@ final class MockSocialService: SocialService {
         try deleteBlockResult.get()
     }
 
-    func getBlockedUsers() async throws -> [BlockedUserResponse] {
+    func getBlockedUsers() async throws -> BlockedUserResponse {
         getBlockedUsersCallCount += 1
         return try getBlockedUsersResult.get()
     }

--- a/Projects/Data/SocialData/Tests/DefaultSocialRepositoryTests.swift
+++ b/Projects/Data/SocialData/Tests/DefaultSocialRepositoryTests.swift
@@ -1,0 +1,190 @@
+//
+//  DefaultSocialRepositoryTests.swift
+//  SocialDataTests
+//
+//  Created by YunhakLee on 4/23/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+@testable import SocialData
+@testable import SocialDataTesting
+import SocialDomain
+import BaseDomain
+import Networking
+
+@Suite
+struct DefaultSocialRepositoryTests {
+
+    // MARK: - blockUser
+
+    @Test("blockUser 성공 시 올바른 userID로 service 호출")
+    func blockUser_success_callsServiceWithCorrectUserID() async throws {
+        let (sut, service, _) = makeRepository()
+
+        try await sut.blockUser(id: UserID(42))
+
+        #expect(service.blockedUserIDs == [42])
+        #expect(service.postBlockUserCallCount == 1)
+    }
+
+    @Test("blockUser 네트워크 오류 시 RepositoryError 변환")
+    func blockUser_networkError_throwsRepositoryError() async {
+        let (sut, service, _) = makeRepository()
+        service.postBlockUserResult = .failure(NetworkingError.unknown(MockError.stub))
+
+        await #expect(throws: RepositoryError.self) {
+            try await sut.blockUser(id: UserID(1))
+        }
+    }
+
+    // MARK: - unblockUser
+
+    @Test("unblockUser 성공 시 올바른 blockID로 service 호출")
+    func unblockUser_success_callsServiceWithCorrectBlockID() async throws {
+        let (sut, service, _) = makeRepository()
+
+        try await sut.unblockUser(id: BlockID(7))
+
+        #expect(service.deletedBlockIDs == [7])
+        #expect(service.deleteBlockCallCount == 1)
+    }
+
+    @Test("unblockUser 네트워크 오류 시 RepositoryError 변환")
+    func unblockUser_networkError_throwsRepositoryError() async {
+        let (sut, service, _) = makeRepository()
+        service.deleteBlockResult = .failure(NetworkingError.unknown(MockError.stub))
+
+        await #expect(throws: RepositoryError.self) {
+            try await sut.unblockUser(id: BlockID(1))
+        }
+    }
+
+    // MARK: - loadBlockedUsers
+
+    @Test("loadBlockedUsers 성공 시 BlockedUser 목록 반환")
+    func loadBlockedUsers_success_returnsBlockedUsers() async throws {
+        let (sut, service, _) = makeRepository()
+        service.getBlockedUsersResult = .success([
+            BlockedUserResponse(blockId: 1, userId: 10, nickname: "차단유저", profileImage: nil),
+            BlockedUserResponse(blockId: 2, userId: 20, nickname: "또차단", profileImage: nil)
+        ])
+
+        let result = try await sut.loadBlockedUsers()
+
+        #expect(result.count == 2)
+        #expect(result[0].blockID == BlockID(1))
+        #expect(result[0].userID == UserID(10))
+        #expect(result[0].nickname == "차단유저")
+        #expect(result[1].blockID == BlockID(2))
+    }
+
+    @Test("loadBlockedUsers 빈 목록 반환")
+    func loadBlockedUsers_emptyList_returnsEmptyArray() async throws {
+        let (sut, service, _) = makeRepository()
+        service.getBlockedUsersResult = .success([])
+
+        let result = try await sut.loadBlockedUsers()
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("loadBlockedUsers 네트워크 오류 시 RepositoryError 변환")
+    func loadBlockedUsers_networkError_throwsRepositoryError() async {
+        let (sut, service, _) = makeRepository()
+        service.getBlockedUsersResult = .failure(NetworkingError.unknown(MockError.stub))
+
+        await #expect(throws: RepositoryError.self) {
+            try await sut.loadBlockedUsers()
+        }
+    }
+
+    // MARK: - reportSpoilerFeed
+
+    @Test("reportSpoilerFeed 성공")
+    func reportSpoilerFeed_success() async throws {
+        let (sut, service, _) = makeRepository()
+
+        try await sut.reportSpoilerFeed(id: FeedID(5))
+
+        #expect(service.reportedSpoilerFeedIDs == [5])
+        #expect(service.postReportSpoilerFeedCallCount == 1)
+    }
+
+    // MARK: - reportImproperFeed
+
+    @Test("reportImproperFeed 성공")
+    func reportImproperFeed_success() async throws {
+        let (sut, service, _) = makeRepository()
+
+        try await sut.reportImproperFeed(id: FeedID(6))
+
+        #expect(service.reportedImproperFeedIDs == [6])
+        #expect(service.postReportImproperFeedCallCount == 1)
+    }
+
+    // MARK: - reportSpoilerComment
+
+    @Test("reportSpoilerComment 성공")
+    func reportSpoilerComment_success() async throws {
+        let (sut, service, _) = makeRepository()
+
+        try await sut.reportSpoilerComment(id: CommentID(3))
+
+        #expect(service.reportedSpoilerCommentIDs == [3])
+        #expect(service.postReportSpoilerCommentCallCount == 1)
+    }
+
+    // MARK: - reportImproperComment
+
+    @Test("reportImproperComment 성공")
+    func reportImproperComment_success() async throws {
+        let (sut, service, _) = makeRepository()
+
+        try await sut.reportImproperComment(id: CommentID(4))
+
+        #expect(service.reportedImproperCommentIDs == [4])
+        #expect(service.postReportImproperCommentCallCount == 1)
+    }
+
+    // MARK: - 네트워크 에러 → RepositoryError 변환
+
+    @Test("NetworkingError.responseFailure 401은 authenticationRequired로 변환")
+    func networkError_401_convertsToAuthenticationRequired() async {
+        let (sut, service, _) = makeRepository()
+        service.postBlockUserResult = .failure(NetworkingError.responseFailure(code: 401, body: nil))
+
+        await #expect(throws: RepositoryError.authenticationRequired) {
+            try await sut.blockUser(id: UserID(1))
+        }
+    }
+
+    @Test("NetworkingError.responseFailure 404는 notFound로 변환")
+    func networkError_404_convertsToNotFound() async {
+        let (sut, service, _) = makeRepository()
+        service.postBlockUserResult = .failure(NetworkingError.responseFailure(code: 404, body: nil))
+
+        await #expect(throws: RepositoryError.notFound) {
+            try await sut.blockUser(id: UserID(1))
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension DefaultSocialRepositoryTests {
+
+    func makeRepository() -> (
+        DefaultSocialRepository,
+        MockSocialService,
+        MockSocialLogger
+    ) {
+        let service = MockSocialService()
+        let logger = MockSocialLogger()
+        let sut = DefaultSocialRepository(
+            service: service,
+            logger: logger
+        )
+        return (sut, service, logger)
+    }
+}

--- a/Projects/Data/SocialData/Tests/DefaultSocialRepositoryTests.swift
+++ b/Projects/Data/SocialData/Tests/DefaultSocialRepositoryTests.swift
@@ -65,10 +65,10 @@ struct DefaultSocialRepositoryTests {
     @Test("loadBlockedUsers 성공 시 BlockedUser 목록 반환")
     func loadBlockedUsers_success_returnsBlockedUsers() async throws {
         let (sut, service, _) = makeRepository()
-        service.getBlockedUsersResult = .success([
-            BlockedUserResponse(blockId: 1, userId: 10, nickname: "차단유저", profileImage: nil),
-            BlockedUserResponse(blockId: 2, userId: 20, nickname: "또차단", profileImage: nil)
-        ])
+        service.getBlockedUsersResult = .success(BlockedUserResponse(blocks: [
+            BlockdUser(blockId: 1, userId: 10, nickname: "차단유저", avatarImage: ""),
+            BlockdUser(blockId: 2, userId: 20, nickname: "또차단", avatarImage: "")
+        ]))
 
         let result = try await sut.loadBlockedUsers()
 
@@ -82,7 +82,7 @@ struct DefaultSocialRepositoryTests {
     @Test("loadBlockedUsers 빈 목록 반환")
     func loadBlockedUsers_emptyList_returnsEmptyArray() async throws {
         let (sut, service, _) = makeRepository()
-        service.getBlockedUsersResult = .success([])
+        service.getBlockedUsersResult = .success(BlockedUserResponse(blocks: []))
 
         let result = try await sut.loadBlockedUsers()
 

--- a/Projects/Data/SocialData/Tests/DefaultSocialRepositoryTests.swift
+++ b/Projects/Data/SocialData/Tests/DefaultSocialRepositoryTests.swift
@@ -11,6 +11,7 @@ import Testing
 @testable import SocialDataTesting
 import SocialDomain
 import BaseDomain
+import BaseData
 import Networking
 
 @Suite
@@ -20,7 +21,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("blockUser 성공 시 올바른 userID로 service 호출")
     func blockUser_success_callsServiceWithCorrectUserID() async throws {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
 
         try await sut.blockUser(id: UserID(42))
 
@@ -30,7 +31,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("blockUser 네트워크 오류 시 RepositoryError 변환")
     func blockUser_networkError_throwsRepositoryError() async {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
         service.postBlockUserResult = .failure(NetworkingError.unknown(MockError.stub))
 
         await #expect(throws: RepositoryError.self) {
@@ -42,7 +43,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("unblockUser 성공 시 올바른 blockID로 service 호출")
     func unblockUser_success_callsServiceWithCorrectBlockID() async throws {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
 
         try await sut.unblockUser(id: BlockID(7))
 
@@ -52,7 +53,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("unblockUser 네트워크 오류 시 RepositoryError 변환")
     func unblockUser_networkError_throwsRepositoryError() async {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
         service.deleteBlockResult = .failure(NetworkingError.unknown(MockError.stub))
 
         await #expect(throws: RepositoryError.self) {
@@ -64,7 +65,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("loadBlockedUsers 성공 시 BlockedUser 목록 반환")
     func loadBlockedUsers_success_returnsBlockedUsers() async throws {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
         service.getBlockedUsersResult = .success(BlockedUserResponse(blocks: [
             BlockdUser(blockId: 1, userId: 10, nickname: "차단유저", avatarImage: ""),
             BlockdUser(blockId: 2, userId: 20, nickname: "또차단", avatarImage: "")
@@ -81,7 +82,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("loadBlockedUsers 빈 목록 반환")
     func loadBlockedUsers_emptyList_returnsEmptyArray() async throws {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
         service.getBlockedUsersResult = .success(BlockedUserResponse(blocks: []))
 
         let result = try await sut.loadBlockedUsers()
@@ -91,7 +92,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("loadBlockedUsers 네트워크 오류 시 RepositoryError 변환")
     func loadBlockedUsers_networkError_throwsRepositoryError() async {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
         service.getBlockedUsersResult = .failure(NetworkingError.unknown(MockError.stub))
 
         await #expect(throws: RepositoryError.self) {
@@ -103,7 +104,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("reportSpoilerFeed 성공")
     func reportSpoilerFeed_success() async throws {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
 
         try await sut.reportSpoilerFeed(id: FeedID(5))
 
@@ -115,7 +116,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("reportImproperFeed 성공")
     func reportImproperFeed_success() async throws {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
 
         try await sut.reportImproperFeed(id: FeedID(6))
 
@@ -127,10 +128,11 @@ struct DefaultSocialRepositoryTests {
 
     @Test("reportSpoilerComment 성공")
     func reportSpoilerComment_success() async throws {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
 
-        try await sut.reportSpoilerComment(id: CommentID(3))
+        try await sut.reportSpoilerComment(feedID: FeedID(1), commentID: CommentID(3))
 
+        #expect(service.reportedSpoilerCommentFeedIDs == [1])
         #expect(service.reportedSpoilerCommentIDs == [3])
         #expect(service.postReportSpoilerCommentCallCount == 1)
     }
@@ -139,10 +141,11 @@ struct DefaultSocialRepositoryTests {
 
     @Test("reportImproperComment 성공")
     func reportImproperComment_success() async throws {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
 
-        try await sut.reportImproperComment(id: CommentID(4))
+        try await sut.reportImproperComment(feedID: FeedID(1), commentID: CommentID(4))
 
+        #expect(service.reportedImproperCommentFeedIDs == [1])
         #expect(service.reportedImproperCommentIDs == [4])
         #expect(service.postReportImproperCommentCallCount == 1)
     }
@@ -151,7 +154,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("NetworkingError.responseFailure 401은 authenticationRequired로 변환")
     func networkError_401_convertsToAuthenticationRequired() async {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
         service.postBlockUserResult = .failure(NetworkingError.responseFailure(code: 401, body: nil))
 
         await #expect(throws: RepositoryError.authenticationRequired) {
@@ -161,7 +164,7 @@ struct DefaultSocialRepositoryTests {
 
     @Test("NetworkingError.responseFailure 404는 notFound로 변환")
     func networkError_404_convertsToNotFound() async {
-        let (sut, service, _) = makeRepository()
+        let (sut, service) = makeRepository()
         service.postBlockUserResult = .failure(NetworkingError.responseFailure(code: 404, body: nil))
 
         await #expect(throws: RepositoryError.notFound) {
@@ -174,17 +177,10 @@ struct DefaultSocialRepositoryTests {
 
 private extension DefaultSocialRepositoryTests {
 
-    func makeRepository() -> (
-        DefaultSocialRepository,
-        MockSocialService,
-        MockSocialLogger
-    ) {
+    func makeRepository() -> (DefaultSocialRepository, MockSocialService) {
         let service = MockSocialService()
-        let logger = MockSocialLogger()
-        let sut = DefaultSocialRepository(
-            service: service,
-            logger: logger
-        )
-        return (sut, service, logger)
+        let logger = DataLogger(moduleName: "SocialDataTests", underlying: nil)
+        let sut = DefaultSocialRepository(service: service, logger: logger)
+        return (sut, service)
     }
 }

--- a/Projects/Domain/SocialDomain/Sources/Entity/BlockedUser.swift
+++ b/Projects/Domain/SocialDomain/Sources/Entity/BlockedUser.swift
@@ -14,4 +14,16 @@ public struct BlockedUser: Equatable {
     public let userID: UserID
     public let nickname: String
     public let profileImageURL: URL?
+    
+    public init(
+        blockID: BlockID,
+        userID: UserID,
+        nickname: String,
+        profileImageURL: URL?
+    ) {
+        self.blockID = blockID
+        self.userID = userID
+        self.nickname = nickname
+        self.profileImageURL = profileImageURL
+    }
 }

--- a/Projects/Domain/SocialDomain/Sources/Repository/SocialRepository.swift
+++ b/Projects/Domain/SocialDomain/Sources/Repository/SocialRepository.swift
@@ -22,6 +22,6 @@ public protocol SocialRepository {
     
     func reportSpoilerFeed(id: FeedID) async throws(RepositoryError)
     func reportImproperFeed(id: FeedID) async throws(RepositoryError)
-    func reportSpoilerComment(id: CommentID) async throws(RepositoryError)
-    func reportImproperComment(id: CommentID) async throws(RepositoryError)
+    func reportSpoilerComment(feedID: FeedID, commentID: CommentID) async throws(RepositoryError)
+    func reportImproperComment(feedID: FeedID, commentID: CommentID) async throws(RepositoryError)
 }

--- a/Projects/Domain/SocialDomain/Sources/UseCase/Report/ReportImproperCommentUseCase.swift
+++ b/Projects/Domain/SocialDomain/Sources/UseCase/Report/ReportImproperCommentUseCase.swift
@@ -11,17 +11,17 @@ import Foundation
 import BaseDomain
 
 public protocol ReportImproperCommentUseCase {
-    func execute(id: CommentID) async throws(RepositoryError)
+    func execute(feedID: FeedID, commentID: CommentID) async throws(RepositoryError)
 }
 
 public final class DefaultReportImproperCommentUseCase: ReportImproperCommentUseCase {
     private let repository: SocialRepository
-    
+
     public init(repository: SocialRepository) {
         self.repository = repository
     }
-    
-    public func execute(id: CommentID) async throws(RepositoryError) {
-        try await repository.reportImproperComment(id: id)
+
+    public func execute(feedID: FeedID, commentID: CommentID) async throws(RepositoryError) {
+        try await repository.reportImproperComment(feedID: feedID, commentID: commentID)
     }
 }

--- a/Projects/Domain/SocialDomain/Sources/UseCase/Report/ReportSpoilerCommentUseCase.swift
+++ b/Projects/Domain/SocialDomain/Sources/UseCase/Report/ReportSpoilerCommentUseCase.swift
@@ -11,17 +11,17 @@ import Foundation
 import BaseDomain
 
 public protocol ReportSpoilerCommentUseCase {
-    func execute(id: CommentID) async throws(RepositoryError)
+    func execute(feedID: FeedID, commentID: CommentID) async throws(RepositoryError)
 }
 
 public final class DefaultReportSpoilerCommentUseCase: ReportSpoilerCommentUseCase {
     private let repository: SocialRepository
-    
+
     public init(repository: SocialRepository) {
         self.repository = repository
     }
-    
-    public func execute(id: CommentID) async throws(RepositoryError) {
-        try await repository.reportSpoilerComment(id: id)
+
+    public func execute(feedID: FeedID, commentID: CommentID) async throws(RepositoryError) {
+        try await repository.reportSpoilerComment(feedID: feedID, commentID: commentID)
     }
 }

--- a/Projects/Domain/SocialDomain/Testing/MockSocialRepository.swift
+++ b/Projects/Domain/SocialDomain/Testing/MockSocialRepository.swift
@@ -70,22 +70,26 @@ public final class MockSocialRepository: SocialRepository {
     // MARK: - Report comment
 
     public var reportSpoilerCommentCallCount = 0
+    public var reportedSpoilerCommentFeedIDs: [FeedID] = []
     public var reportedSpoilerCommentIDs: [CommentID] = []
     public var reportSpoilerCommentResult: Result<Void, RepositoryError> = .success(())
 
-    public func reportSpoilerComment(id: CommentID) async throws(RepositoryError) {
+    public func reportSpoilerComment(feedID: FeedID, commentID: CommentID) async throws(RepositoryError) {
         reportSpoilerCommentCallCount += 1
-        reportedSpoilerCommentIDs.append(id)
+        reportedSpoilerCommentFeedIDs.append(feedID)
+        reportedSpoilerCommentIDs.append(commentID)
         _ = try reportSpoilerCommentResult.get()
     }
 
     public var reportImproperCommentCallCount = 0
+    public var reportedImproperCommentFeedIDs: [FeedID] = []
     public var reportedImproperCommentIDs: [CommentID] = []
     public var reportImproperCommentResult: Result<Void, RepositoryError> = .success(())
 
-    public func reportImproperComment(id: CommentID) async throws(RepositoryError) {
+    public func reportImproperComment(feedID: FeedID, commentID: CommentID) async throws(RepositoryError) {
         reportImproperCommentCallCount += 1
-        reportedImproperCommentIDs.append(id)
+        reportedImproperCommentFeedIDs.append(feedID)
+        reportedImproperCommentIDs.append(commentID)
         _ = try reportImproperCommentResult.get()
     }
 }

--- a/Projects/Domain/SocialDomain/Tests/UseCase/Report/ReportImproperCommentUseCaseTests.swift
+++ b/Projects/Domain/SocialDomain/Tests/UseCase/Report/ReportImproperCommentUseCaseTests.swift
@@ -22,10 +22,12 @@ struct ReportImproperCommentUseCaseTests {
 
         let sut = DefaultReportImproperCommentUseCase(repository: repo)
 
+        let feedID = FeedID(1)
         let commentID = CommentID(8)
-        try await sut.execute(id: commentID)
+        try await sut.execute(feedID: feedID, commentID: commentID)
 
         #expect(repo.reportImproperCommentCallCount == 1)
+        #expect(repo.reportedImproperCommentFeedIDs == [feedID])
         #expect(repo.reportedImproperCommentIDs == [commentID])
     }
 
@@ -37,7 +39,7 @@ struct ReportImproperCommentUseCaseTests {
         let sut = DefaultReportImproperCommentUseCase(repository: repo)
 
         await #expect(throws: RepositoryError.serverUnavailable) {
-            try await sut.execute(id: CommentID(8))
+            try await sut.execute(feedID: FeedID(1), commentID: CommentID(8))
         }
 
         #expect(repo.reportImproperCommentCallCount == 1)

--- a/Projects/Domain/SocialDomain/Tests/UseCase/Report/ReportSpoilerCommentUseCaseTests.swift
+++ b/Projects/Domain/SocialDomain/Tests/UseCase/Report/ReportSpoilerCommentUseCaseTests.swift
@@ -22,10 +22,12 @@ struct ReportSpoilerCommentUseCaseTests {
 
         let sut = DefaultReportSpoilerCommentUseCase(repository: repo)
 
+        let feedID = FeedID(1)
         let commentID = CommentID(7)
-        try await sut.execute(id: commentID)
+        try await sut.execute(feedID: feedID, commentID: commentID)
 
         #expect(repo.reportSpoilerCommentCallCount == 1)
+        #expect(repo.reportedSpoilerCommentFeedIDs == [feedID])
         #expect(repo.reportedSpoilerCommentIDs == [commentID])
     }
 
@@ -37,7 +39,7 @@ struct ReportSpoilerCommentUseCaseTests {
         let sut = DefaultReportSpoilerCommentUseCase(repository: repo)
 
         await #expect(throws: RepositoryError.networkUnavailable) {
-            try await sut.execute(id: CommentID(7))
+            try await sut.execute(feedID: FeedID(1), commentID: CommentID(7))
         }
 
         #expect(repo.reportSpoilerCommentCallCount == 1)


### PR DESCRIPTION
## 💡 Issue                
  closed #87
                                              
  <br>                                    

  ## 💭 Summary                                                    
  SocialData 모듈의 데모 앱을 추가하고, 기존 구현 코드의 버그를
  수정합니다.                                                      
                                          
  <br>
                                                                   
  ## 🔑 Key Changes                           
                                                                   
  **SocialData Demo 앱 추가**
  - `Project.swift`에 demo 타겟 추가                               
  - Block(차단/해제/목록 조회), Report Feed(스포일러/부적절),
  Report Comment(스포일러/부적절) 기능 구현                        
  - 버튼별 파스텔 색상 적용 및 요청 후 텍스트 필드 자동 초기화

  **SocialData 버그 수정**                                         
  - `MockSocialService` 댓글 신고 메서드에 누락된 `feedID` 파라미터
   추가                                                            
  - `SocialLogger` 프로토콜 제거 이후 남아있던 `MockSocialLogger`  
  삭제                                        
  - `DefaultSocialRepositoryTests` 댓글 신고 테스트 시그니처 수정  
  (`id:` → `feedID:commentID:`)               
  - `SocialEndpoint` `unblockUser` 파라미터명 `userID` → `blockId` 
  수정
  - `SocialEndpoint` `baseURL` `NetworkingConfig` 연동             
                                              
  **SocialDomain**                                                 
  - `BlockedUser` 엔티티 `public init` 추가
  - 댓글 신고 시그니처에 `feedID` 추가                             
                                              
  <br>                                                             
                  
  ## 📱 Simulation      
                                           

          
  <br>            