### PR TITLE
[Chore] #125 - NovelData 내 NovelMapper 보충 

### DIFF
--- a/Projects/Data/NovelData/Demo/NovelLoggerDemoView.swift
+++ b/Projects/Data/NovelData/Demo/NovelLoggerDemoView.swift
@@ -26,11 +26,9 @@ struct NovelLoggerDemoView: View {
         let userDefaults = UserDefaultsStorage()
         userDefaults.set(.userID, 10035)
         let logger = DataLogger(moduleName: "NovelData", underlying: OSLogger.novel)
-        let keywordRepository = KeywordDataFactory.makeRepository(client: client)
-        self.keywordRepository = keywordRepository
+        self.keywordRepository = KeywordDataFactory.makeRepository(client: client)
         self.repository = NovelDataFactory.makeNovelRepository(client: client,
                                                                appStorage: userDefaults,
-                                                               keywordRepository: keywordRepository,
                                                                logger: logger)
     }
     
@@ -180,7 +178,8 @@ struct NovelLoggerDemoView: View {
     private func fetchNovel(novelID: Int) async {
         appendLog(level: .debug, message: "작품 정보 조회 (ID=\(novelID)) 요청...")
         do {
-            let info = try await repository.fetchNovel(id: NovelID(novelID))
+            let cachedKeywords = (try? await keywordRepository.fetchKeywords())?.flatMap(\.keywords) ?? []
+            let info = try await repository.fetchNovel(id: NovelID(novelID), cachedKeywords: cachedKeywords)
             let novel = info.novel
             appendLog(level: .info,
                       message: "성공: \(novel.title) | 장르: \(info.genres) | 평점: \(novel.rating) | 피드: \(info.feedCount)개 | 키워드: \(info.keywords)")
@@ -241,7 +240,7 @@ struct NovelLoggerDemoView: View {
     }
     
     private func fetchUserLibraryNovels(userID: Int) async {
-        appendLog(level: .debug, message: "유저 서재 조회 (ID=\(userID)) 요청...")
+        appendLog(level: .debug, message: "유저 서재 조회 (ID=\(10033)) 요청...")
         do {
             let filter = LibraryFilter(sortType: .recent)
             let (paginated, totalCount) = try await repository.fetchUserLibraryNovels(id: UserID(userID), filter)

--- a/Projects/Data/NovelData/Demo/NovelLoggerDemoView.swift
+++ b/Projects/Data/NovelData/Demo/NovelLoggerDemoView.swift
@@ -17,19 +17,23 @@ import BaseData
 struct NovelLoggerDemoView: View {
     @State private var logs: [LogEntry] = []
     @State private var isLoading: Bool = false
-
+    
     private let repository: NovelRepository
-
+    private let keywordRepository: KeywordRepository
+    
     init() {
         let client = NetworkingClient()
         let userDefaults = UserDefaultsStorage()
         userDefaults.set(.userID, 10035)
         let logger = DataLogger(moduleName: "NovelData", underlying: OSLogger.novel)
+        let keywordRepository = KeywordDataFactory.makeRepository(client: client)
+        self.keywordRepository = keywordRepository
         self.repository = NovelDataFactory.makeNovelRepository(client: client,
                                                                appStorage: userDefaults,
+                                                               keywordRepository: keywordRepository,
                                                                logger: logger)
     }
-
+    
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -40,11 +44,14 @@ struct NovelLoggerDemoView: View {
                     .frame(maxHeight: 340)
             }
             .navigationTitle("NovelData Demo")
+            .task {
+                await keywordRepository.syncKeywords()
+            }
         }
     }
-
+    
     // MARK: - Log List
-
+    
     private var logListView: some View {
         ScrollViewReader { proxy in
             ScrollView {
@@ -63,7 +70,7 @@ struct NovelLoggerDemoView: View {
             }
         }
     }
-
+    
     private func logRow(_ entry: LogEntry) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(entry.timestamp)
@@ -78,87 +85,87 @@ struct NovelLoggerDemoView: View {
         .background(entry.level.backgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: 6))
     }
-
+    
     // MARK: - Button Section
-
+    
     private var buttonSection: some View {
         ScrollView {
             VStack(spacing: 12) {
-
+                
                 // MARK: 작품 정보 조회
-
+                
                 sectionHeader("작품 정보 조회")
-
+                
                 HStack(spacing: 12) {
-                    asyncButton("작품 조회 (ID=1)", color: .indigo) {
-                        await fetchNovel(novelID: 1)
+                    asyncButton("작품 조회 (ID=6891)", color: .indigo) {
+                        await fetchNovel(novelID: 6891)
                     }
-
-                    asyncButton("작품 조회 (ID=23)", color: .orange) {
-                        await fetchNovel(novelID: 23)
+                    
+                    asyncButton("작품 조회 (ID=11131)", color: .orange) {
+                        await fetchNovel(novelID: 11131)
                     }
                 }
-
+                
                 Divider()
-
+                
                 // MARK: 관심 등록/해제
-
+                
                 sectionHeader("관심 등록 / 해제")
-
+                
                 HStack(spacing: 12) {
                     asyncButton("관심 등록 (ID=1)", color: .teal) {
                         await addNovelInterest(novelID: 1)
                     }
-
+                    
                     asyncButton("관심 해제 (ID=1)", color: .pink) {
                         await removeNovelInterest(novelID: 1)
                     }
                 }
-
+                
                 Divider()
-
+                
                 // MARK: 검색
-
+                
                 sectionHeader("작품 검색")
-
+                
                 HStack(spacing: 12) {
                     asyncButton("텍스트 검색 '소녀'", color: .cyan) {
                         await searchNovelByText("소녀")
                     }
-
+                    
                     asyncButton("텍스트 검색 ''(빈값)", color: .orange) {
                         await searchNovelByText("")
                     }
                 }
-
+                
                 HStack(spacing: 12) {
                     asyncButton("필터 검색 (로맨스)", color: .purple) {
                         await searchNovelByFilter()
                     }
                 }
-
+                
                 Divider()
-
+                
                 // MARK: 서재 / 통계
-
+                
                 sectionHeader("서재 / 통계 조회")
-
+                
                 HStack(spacing: 12) {
                     asyncButton("내 서재", color: .mint) {
                         await fetchMyLibraryNovels()
                     }
-
+                    
                     asyncButton("유저 서재 (ID=1)", color: .mint) {
                         await fetchUserLibraryNovels(userID: 10032)
                     }
                 }
-
+                
                 HStack(spacing: 12) {
                     asyncButton("등록 통계", color: .mint) {
                         await fetchRegisteredNovelStats()
                     }
                 }
-
+                
                 Button("Clear") { logs.removeAll() }
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -167,21 +174,21 @@ struct NovelLoggerDemoView: View {
         }
         .background(Color(.systemGroupedBackground))
     }
-
+    
     // MARK: - API Calls
-
+    
     private func fetchNovel(novelID: Int) async {
         appendLog(level: .debug, message: "작품 정보 조회 (ID=\(novelID)) 요청...")
         do {
             let info = try await repository.fetchNovel(id: NovelID(novelID))
             let novel = info.novel
             appendLog(level: .info,
-                      message: "성공: \(novel.title) | 장르: \(info.genres) | 평점: \(novel.rating) | 피드: \(info.feedCount)개")
+                      message: "성공: \(novel.title) | 장르: \(info.genres) | 평점: \(novel.rating) | 피드: \(info.feedCount)개 | 키워드: \(info.keywords)")
         } catch {
             appendError(action: .fetchNovel, error: error)
         }
     }
-
+    
     private func addNovelInterest(novelID: Int) async {
         appendLog(level: .debug, message: "관심 등록 (ID=\(novelID)) 요청...")
         do {
@@ -191,7 +198,7 @@ struct NovelLoggerDemoView: View {
             appendError(action: .addInterest, error: error)
         }
     }
-
+    
     private func removeNovelInterest(novelID: Int) async {
         appendLog(level: .debug, message: "관심 해제 (ID=\(novelID)) 요청...")
         do {
@@ -201,7 +208,7 @@ struct NovelLoggerDemoView: View {
             appendError(action: .removeInterest, error: error)
         }
     }
-
+    
     private func searchNovelByText(_ text: String) async {
         appendLog(level: .debug, message: "텍스트 검색 '\(text)' 요청...")
         do {
@@ -213,7 +220,7 @@ struct NovelLoggerDemoView: View {
             appendError(action: .searchByText(query: text), error: error)
         }
     }
-
+    
     private func fetchMyLibraryNovels() async {
         appendLog(level: .debug, message: "내 서재 조회 요청...")
         do {
@@ -232,7 +239,7 @@ struct NovelLoggerDemoView: View {
             appendError(action: .fetchMyLibrary, error: error)
         }
     }
-
+    
     private func fetchUserLibraryNovels(userID: Int) async {
         appendLog(level: .debug, message: "유저 서재 조회 (ID=\(userID)) 요청...")
         do {
@@ -245,7 +252,7 @@ struct NovelLoggerDemoView: View {
             appendError(action: .fetchUserLibrary, error: error)
         }
     }
-
+    
     private func searchNovelByFilter() async {
         appendLog(level: .debug, message: "필터 검색 (로맨스) 요청...")
         do {
@@ -261,7 +268,7 @@ struct NovelLoggerDemoView: View {
             appendError(action: .searchByFilter, error: error)
         }
     }
-
+    
     private func fetchRegisteredNovelStats() async {
         appendLog(level: .debug, message: "등록 작품 통계 조회 요청...")
         do {
@@ -272,19 +279,19 @@ struct NovelLoggerDemoView: View {
             appendError(action: .fetchRegisteredStats, error: error)
         }
     }
-
+    
     // MARK: - Helpers
-
+    
     private func appendError(action: NovelAction, error: Error) {
         appendLog(level: .error, message: "실패: \(error)")
     }
-
+    
     private func sectionHeader(_ text: String) -> some View {
         Text(text)
             .font(.caption)
             .foregroundStyle(.secondary)
     }
-
+    
     private func asyncButton(
         _ title: String,
         color: Color,
@@ -296,12 +303,12 @@ struct NovelLoggerDemoView: View {
             .font(.callout)
             .disabled(isLoading)
     }
-
+    
     private func appendLog(level: LogLevel, message: String) {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss.SSS"
         let timestamp = formatter.string(from: Date())
-
+        
         logs.append(LogEntry(
             timestamp: timestamp,
             level: level,
@@ -321,7 +328,7 @@ private struct LogEntry: Identifiable {
 
 private enum LogLevel {
     case debug, info, error
-
+    
     var color: Color {
         switch self {
         case .debug: return .blue
@@ -329,7 +336,7 @@ private enum LogLevel {
         case .error: return .red
         }
     }
-
+    
     var backgroundColor: Color {
         switch self {
         case .debug: return .blue.opacity(0.08)

--- a/Projects/Data/NovelData/Sources/Factory/NovelDataFactory.swift
+++ b/Projects/Data/NovelData/Sources/Factory/NovelDataFactory.swift
@@ -7,7 +7,6 @@
 //
 
 
-import BaseDomain
 import Logger
 import Networking
 import NovelDomain
@@ -17,7 +16,6 @@ public enum NovelDataFactory {
     public static func makeNovelRepository(
         client: NetworkingRequestable,
         appStorage: AppStorage,
-        keywordRepository: KeywordRepository,
         logger: DataLogger? = nil
     ) -> NovelRepository {
         let service = DefaultNovelService(client: client)
@@ -25,7 +23,6 @@ public enum NovelDataFactory {
         return DefaultNovelRepository(
             service: service,
             appStorage: userDefaultsStorage,
-            keywordRepository: keywordRepository,
             logger: logger
         )
     }

--- a/Projects/Data/NovelData/Sources/Factory/NovelDataFactory.swift
+++ b/Projects/Data/NovelData/Sources/Factory/NovelDataFactory.swift
@@ -7,6 +7,7 @@
 //
 
 
+import BaseDomain
 import Logger
 import Networking
 import NovelDomain
@@ -16,6 +17,7 @@ public enum NovelDataFactory {
     public static func makeNovelRepository(
         client: NetworkingRequestable,
         appStorage: AppStorage,
+        keywordRepository: KeywordRepository,
         logger: DataLogger? = nil
     ) -> NovelRepository {
         let service = DefaultNovelService(client: client)
@@ -23,6 +25,7 @@ public enum NovelDataFactory {
         return DefaultNovelRepository(
             service: service,
             appStorage: userDefaultsStorage,
+            keywordRepository: keywordRepository,
             logger: logger
         )
     }

--- a/Projects/Data/NovelData/Sources/Mapper/NovelMapper.swift
+++ b/Projects/Data/NovelData/Sources/Mapper/NovelMapper.swift
@@ -143,9 +143,11 @@ extension NovelMapper {
     
     //MARK: - 일반 검색 작품
     
-//    public static func searchNovels(from dto: SearchNovelsResponse) -> (Paginated<Novel>, Int) {
-//        return (dto.novels.map { searchNovel(from: $0) }, dto.resultCount)
-//    }
+    public static func searchNovels(from dto: SearchNovelsResponse) -> (Paginated<Novel>, Int) {
+        let novels = dto.novels.map { searchNovel(from: $0) }
+        let paginated = Paginated(items: novels, hasNext: dto.isLoadable)
+        return (paginated, dto.resultCount)
+    }
     
     public static func searchNovel(from dto: SearchNovelResponse) -> Novel {
         let thumbnailImageURL = URL(string: dto.novelImage)

--- a/Projects/Data/NovelData/Sources/Mapper/NovelMapper.swift
+++ b/Projects/Data/NovelData/Sources/Mapper/NovelMapper.swift
@@ -72,14 +72,14 @@ extension NovelMapper {
     // MARK: - 작품 상세 정보
     
     public static func novelInformation(id: NovelID,
-                                              from basicDTO: NovelBasicResponse,
-                                              from detailDTO: NovelInfoResponse) throws -> NovelInformation {
+                                        from basicDTO: NovelBasicResponse,
+                                        from detailDTO: NovelInfoResponse,
+                                        cachedKeywords: [Keyword]) throws -> NovelInformation {
         let authors = basicDTO.author
             .components(separatedBy: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
         
         let novel = Novel(
-            //TODO: - id값을 어떻게 처리하면 좋을지 고민
             id: id,
             thumbnailImage: URL(string: basicDTO.novelGenreImage),
             title: basicDTO.novelTitle,
@@ -119,9 +119,7 @@ extension NovelMapper {
             description: detailDTO.novelDescription,
             platforms: platforms,
             attractivePoints: try detailDTO.attractivePoints.map { try mapAttractivePoint(from: $0) },
-            // TODO: - Keyword 매핑 추가 필요 (KeywordID 문제 해결 후)
-            // 앱 시작할 떄 변수에 키워드를 저장하고, Data모듈에서 매핑하는 방식으로 합니다.
-            keywords: [:],
+            keywords: mapKeywords(from: detailDTO.keywords, cachedKeywords: cachedKeywords),
             readingStatusCount: [
                 .watching: detailDTO.watchingCount,
                 .watched: detailDTO.watchedCount,
@@ -170,9 +168,9 @@ extension NovelMapper {
 //MARK: - Entity -> DTO
 
 extension NovelMapper {
-
+    
     // MARK: - 서재 조회 Query
-
+    
     static func myLibraryQuery(from filter: MyLibraryFilter) -> UserLibraryQuery {
         UserLibraryQuery(
             lastUserNovelId: 0,
@@ -186,7 +184,7 @@ extension NovelMapper {
             updatedSince: ""
         )
     }
-
+    
     static func userLibraryQuery(from filter: LibraryFilter) -> UserLibraryQuery {
         UserLibraryQuery(
             lastUserNovelId: 0,
@@ -200,9 +198,9 @@ extension NovelMapper {
             updatedSince: ""
         )
     }
-
+    
     // MARK: - 상세 탐색 Query
-
+    
     static func detailSearchQuery(from filter: SearchFilter) -> DetailSearchQuery {
         DetailSearchQuery(
             genres: filter.genres.map { mapNovelGenreString(from: $0) },
@@ -235,33 +233,29 @@ extension NovelMapper {
     }
     
     private static func mapReadingStatusString(from value: ReadingStatus) -> String {
-        switch value {
-        case .watching: return "WATCHING"
-        case .watched: return "WATCHED"
-        case .quit: return "QUIT"
-        }
+        return value.rawValue.uppercased()
     }
     
     private static func mapAttractivePoint(from value: String) throws -> AttractivePoint {
         switch value {
-        case "worldview": return .worldview
-        case "material": return .material
-        case "character": return .character
-        case "relationship": return .relationship
-        case "vibe": return .vibe
-        case "writingskill": return .writingSkill
-        default: throw MappingError.invalidAttractivePoint(value)
+        case "worldview":       return .worldview
+        case "material":        return .material
+        case "character":       return .character
+        case "relationship":    return .relationship
+        case "vibe":            return .vibe
+        case "writingskill":    return .writingSkill
+        default:                throw MappingError.invalidAttractivePoint(value)
         }
     }
     
     private static func mapAttractivePointString(from value: AttractivePoint) -> String {
         switch value {
-        case .worldview: return "worldview"
-        case .material: return "material"
-        case .character: return "character"
-        case .relationship: return "relationship"
-        case .vibe: return "vibe"
-        case .writingSkill: return "writingskill"
+        case .worldview:        return "worldview"
+        case .material:         return "material"
+        case .character:        return "character"
+        case .relationship:     return "relationship"
+        case .vibe:             return "vibe"
+        case .writingSkill:     return "writingskill"
         }
     }
     
@@ -302,24 +296,31 @@ extension NovelMapper {
         case .mystery:         return "mystery"
         }
     }
-
+    
     private static func mapNovelGenre(from value: String) throws -> NovelGenre {
         switch value {
-        case "lightNovel":      return .lightNovel
-        case "wuxia":           return .wuxia
-        case "fantasy":         return .fantasy
-        case "romance":         return .romance
-        case "BL":              return .BL
-        case "romanceFantasy":  return .romanceFantasy
-        case "modernFantasy":   return .modernFantasy
-        case "drama":           return .drama
-        case "mystery":         return .mystery
-        default:                throw MappingError.invalidNovelGenre(value)
+        case "라노벨":   return .lightNovel
+        case "무협":    return .wuxia
+        case "판타지":   return .fantasy
+        case "로맨스":   return .romance
+        case "BL":     return .BL
+        case "로판":    return .romanceFantasy
+        case "현판":    return .modernFantasy
+        case "드라마":   return .drama
+        case "미스테리":  return .mystery
+        default:        throw MappingError.invalidNovelGenre(value)
         }
     }
     
     private static func mapPublicationStatus(from isCompleted: Bool) -> NovelPublicationStatus {
         isCompleted ? .completed : .onGoing
+    }
+    
+    private static func mapKeywords(from dtos: [NovelKeywordResponse],
+                                    cachedKeywords: [Keyword]) -> [Keyword] {
+        dtos.compactMap { dto in
+            cachedKeywords.first { $0.name == dto.keywordName }
+        }
     }
     
     private static func mapPlatform(from dto: NovelPlatformResponse) throws -> NovelPlatform {

--- a/Projects/Data/NovelData/Sources/Repository/DefaultNovelRepository.swift
+++ b/Projects/Data/NovelData/Sources/Repository/DefaultNovelRepository.swift
@@ -96,10 +96,9 @@ public struct DefaultNovelRepository: NovelRepository {
         
         do {
             let response = try await service.getNormalSearchNovels(query: query)
-            let novels = response.novels.map { NovelMapper.searchNovel(from: $0) }
-            let paginated = Paginated(items: novels, hasNext: response.isLoadable)
+            let result = NovelMapper.searchNovels(from: response)
             logger?.logSuccess(action: action.text)
-            return (paginated, response.resultCount)
+            return result
         } catch let error as NetworkingError {
             logger?.logNetworkError(action: action.text, error: error)
             throw error.toRepositoryError()
@@ -111,17 +110,16 @@ public struct DefaultNovelRepository: NovelRepository {
             throw .unknown
         }
     }
-
+    
     public func searchNovelByFilter(_ filter: SearchFilter) async throws(RepositoryError) -> (Paginated<Novel>, Int) {
         let action = NovelAction.searchByFilter
         
         do {
             let query = NovelMapper.detailSearchQuery(from: filter)
             let response = try await service.getDetailSearchNovels(query: query)
-            let novels = response.novels.map { NovelMapper.searchNovel(from: $0) }
-            let paginated = Paginated(items: novels, hasNext: response.isLoadable)
+            let result = NovelMapper.searchNovels(from: response)
             logger?.logSuccess(action: action.text)
-            return (paginated, response.resultCount)
+            return result
         } catch let error as NetworkingError {
             logger?.logNetworkError(action: action.text, error: error)
             throw error.toRepositoryError()

--- a/Projects/Data/NovelData/Sources/Repository/DefaultNovelRepository.swift
+++ b/Projects/Data/NovelData/Sources/Repository/DefaultNovelRepository.swift
@@ -14,28 +14,35 @@ import Networking
 import BaseData
 
 public struct DefaultNovelRepository: NovelRepository {
-
+    
     private let service: NovelService
     private let appStorage: AppStorage
+    private let keywordRepository: KeywordRepository
     private let logger: DataLogger?
-
+    
     init(
         service: NovelService,
         appStorage: AppStorage,
+        keywordRepository: KeywordRepository,
         logger: DataLogger?
     ) {
         self.service = service
         self.appStorage = appStorage
+        self.keywordRepository = keywordRepository
         self.logger = logger
     }
-
+    
     public func fetchNovel(id: NovelID) async throws(RepositoryError) -> NovelInformation {
         let action = NovelAction.fetchNovel
         do {
             let basic = try await service.getNovelBasicInfo(novelID: id.value)
             let detail = try await service.getNovelDetailInfo(novelID: id.value)
+            let cachedKeywords = (try? await keywordRepository.fetchKeywords())?.flatMap(\.keywords) ?? []
             
-            let result = try NovelMapper.novelInformation(id: id, from: basic, from: detail)
+            let result = try NovelMapper.novelInformation(id: id,
+                                                          from: basic,
+                                                          from: detail,
+                                                          cachedKeywords: cachedKeywords)
             logger?.logSuccess(action: action.text)
             return result
         } catch let error as NetworkingError {
@@ -49,7 +56,7 @@ public struct DefaultNovelRepository: NovelRepository {
             throw .unknown
         }
     }
-
+    
     public func addNovelInterest(id: NovelID) async throws(RepositoryError) {
         let action = NovelAction.addInterest
         
@@ -67,7 +74,7 @@ public struct DefaultNovelRepository: NovelRepository {
             throw .unknown
         }
     }
-
+    
     public func removeNovelInterest(id: NovelID) async throws(RepositoryError) {
         let action = NovelAction.removeInterest
         
@@ -85,7 +92,7 @@ public struct DefaultNovelRepository: NovelRepository {
             throw .unknown
         }
     }
-
+    
     public func searchNovelByText(_ text: String) async throws(RepositoryError) -> (Paginated<Novel>, Int) {
         let action = NovelAction.searchByText(query: text)
         let query = NormalSearchQuery(
@@ -131,7 +138,7 @@ public struct DefaultNovelRepository: NovelRepository {
             throw .unknown
         }
     }
-
+    
     public func fetchMyLibraryNovels(_ filter: MyLibraryFilter) async throws(RepositoryError) -> (Paginated<LibraryNovel>, Int) {
         let action = NovelAction.fetchMyLibrary
         
@@ -154,11 +161,11 @@ public struct DefaultNovelRepository: NovelRepository {
             throw .unknown
         }
     }
-
+    
     public func fetchUserLibraryNovels(id: UserID,
                                        _ filter: LibraryFilter) async throws(RepositoryError) -> (Paginated<LibraryNovel>, Int) {
         let action = NovelAction.fetchUserLibrary
-
+        
         do {
             let query = NovelMapper.userLibraryQuery(from: filter)
             let response = try await service.getUserLibraryNovels(userID: id.value, query: query)
@@ -176,7 +183,7 @@ public struct DefaultNovelRepository: NovelRepository {
             throw .unknown
         }
     }
-
+    
     public func fetchRegisteredNovelStats() async throws(RepositoryError) -> RegisteredNovelStats {
         let action = NovelAction.fetchRegisteredStats
         

--- a/Projects/Data/NovelData/Sources/Repository/DefaultNovelRepository.swift
+++ b/Projects/Data/NovelData/Sources/Repository/DefaultNovelRepository.swift
@@ -17,28 +17,24 @@ public struct DefaultNovelRepository: NovelRepository {
     
     private let service: NovelService
     private let appStorage: AppStorage
-    private let keywordRepository: KeywordRepository
     private let logger: DataLogger?
-    
+
     init(
         service: NovelService,
         appStorage: AppStorage,
-        keywordRepository: KeywordRepository,
         logger: DataLogger?
     ) {
         self.service = service
         self.appStorage = appStorage
-        self.keywordRepository = keywordRepository
         self.logger = logger
     }
-    
-    public func fetchNovel(id: NovelID) async throws(RepositoryError) -> NovelInformation {
+
+    public func fetchNovel(id: NovelID, cachedKeywords: [Keyword]) async throws(RepositoryError) -> NovelInformation {
         let action = NovelAction.fetchNovel
         do {
             let basic = try await service.getNovelBasicInfo(novelID: id.value)
             let detail = try await service.getNovelDetailInfo(novelID: id.value)
-            let cachedKeywords = (try? await keywordRepository.fetchKeywords())?.flatMap(\.keywords) ?? []
-            
+
             let result = try NovelMapper.novelInformation(id: id,
                                                           from: basic,
                                                           from: detail,

--- a/Projects/Domain/NovelDomain/Sources/Entity/Novel/NovelInformation.swift
+++ b/Projects/Domain/NovelDomain/Sources/Entity/Novel/NovelInformation.swift
@@ -25,7 +25,7 @@ public struct NovelInformation {
     public let description: String
     public let platforms: [NovelPlatform]
     public let attractivePoints: [AttractivePoint]
-    public let keywords: [Keyword : Int]
+    public let keywords: [Keyword]
     public let readingStatusCount: [ReadingStatus : Int]
     
     public init(
@@ -37,7 +37,7 @@ public struct NovelInformation {
         description: String,
         platforms: [NovelPlatform],
         attractivePoints: [AttractivePoint],
-        keywords: [Keyword : Int],
+        keywords: [Keyword],
         readingStatusCount: [ReadingStatus : Int]
     ) {
         self.novel = novel

--- a/Projects/Domain/NovelDomain/Sources/Repository/NovelRepository.swift
+++ b/Projects/Domain/NovelDomain/Sources/Repository/NovelRepository.swift
@@ -17,7 +17,8 @@ public protocol NovelRepository {
     /// - 작품의 상세 정보(NovelInformation)
     ///
     /// 위 두 정보를 한 번의 요청으로 함께 반환한다.
-    func fetchNovel(id: NovelID) async throws(RepositoryError) -> NovelInformation
+    /// 키워드 매핑을 위해 캐시된 키워드 목록을 전달받는다.
+    func fetchNovel(id: NovelID, cachedKeywords: [Keyword]) async throws(RepositoryError) -> NovelInformation
     
     func addNovelInterest(id: NovelID) async throws(RepositoryError)
     func removeNovelInterest(id: NovelID) async throws(RepositoryError)

--- a/Projects/Domain/NovelDomain/Sources/UseCase/LoadNovelUseCase.swift
+++ b/Projects/Domain/NovelDomain/Sources/UseCase/LoadNovelUseCase.swift
@@ -17,12 +17,16 @@ public protocol LoadNovelUseCase {
 public final class DefaultLoadNovelUseCase: LoadNovelUseCase {
 
     private let novelRepository: NovelRepository
+    private let keywordRepository: KeywordRepository
 
-    public init(novelRepository: NovelRepository) {
+    public init(novelRepository: NovelRepository,
+                keywordRepository: KeywordRepository) {
         self.novelRepository = novelRepository
+        self.keywordRepository = keywordRepository
     }
 
     public func execute(id: NovelID) async throws(RepositoryError) -> NovelInformation {
-        return try await novelRepository.fetchNovel(id: id)
+        let cachedKeywords = (try? await keywordRepository.fetchKeywords())?.flatMap(\.keywords) ?? []
+        return try await novelRepository.fetchNovel(id: id, cachedKeywords: cachedKeywords)
     }
 }


### PR DESCRIPTION
## 💡 Issue
<!-- closed #1 -->
- closed #125 
<br>

## 💭 Summary
<!-- 작업에 대한 간단한 소개 -->
NovelData 내 NovelMapper 파트 보충했습니다. 
<br>

## 🔑 Key Changes
<!-- 작업에 대한 구체적인 설명 -->
#### 키워드 매핑 기능 추가 
API의 `keyword​Name`을 캐시된 키워드 목록에서 이름 기반으로 매칭하여 Keyword 엔티티로 변환 `map​Keywords` 추가했습니다. 

#### Repository 간 의존성 제거 및 UseCase 조합 구조로 리팩토링
키워드 매핑을 위해 처음에는 Default​Novel​Repository에 Keyword​Repository를 주입하는 방식으로 구현했습니다.

그러나 Clean Architecture 관점에서 `Repository`는 하나의 데이터 소스에 대한 접근을 캡슐화하는 역할이므로, 
Repository가 또 다른 Repository를 의존하는 것은 책임 경계가 모호해지고, 순환 의존으로 인해 부적절한 구조라고 판단했습니다.

이에 Novel​Repository​.fetch​Novel이 cached​Keywords를 외부에서 전달받도록 변경했습니다.
두 Repository의 결과를 조합하는 책임은 **Default​Load​Novel​Use​Case**로 이동시켜, 
UseCase에서 Keyword​Repository로 캐시된 키워드를 조회한 뒤 Novel​Repository​.fetch​Novel에 전달하는 구조로 변경했습니다.
<br>

## 📱 Simulation
<!-- 작업에 대한 UI 시뮬레이터 -->

<br>

## 🧑‍🧒‍🧒 To Reviewer
<!-- 리뷰어에게 전달할 내용 -->

<br>

## ※ Reference
<!-- 작업 시 참고한 레퍼런스 -->
