### PR TITLE
[Chore] #134 - FeedData multipart 통신 시 이미지 압축 구현

### DIFF
--- a/Projects/Data/FeedData/Demo/FeedDataDemoView.swift
+++ b/Projects/Data/FeedData/Demo/FeedDataDemoView.swift
@@ -278,12 +278,11 @@ struct FeedDataDemoView: View {
     }
 
     private func loadSelectedImages(_ items: [PhotosPickerItem]) async {
+        // 원본 Data를 그대로 보관합니다. 압축은 Repository가 업로드 직전에 수행합니다.
         var datas: [Data] = []
         for item in items {
-            guard let raw = try? await item.loadTransferable(type: Data.self),
-                  let image = UIImage(data: raw),
-                  let jpeg = image.jpegData(compressionQuality: 0.8) else { continue }
-            datas.append(jpeg)
+            guard let raw = try? await item.loadTransferable(type: Data.self) else { continue }
+            datas.append(raw)
         }
         selectedImageDatas = datas
     }
@@ -344,10 +343,11 @@ struct FeedDataDemoView: View {
         )
         let imageDatas = selectedImageDatas
         let url = "/feeds"
+        let compressionLog = await makeCompressionLog(for: imageDatas)
         isLoading = true; defer { isLoading = false }
         do {
             try await repository.submitFeed(draft, imageDatas: imageDatas)
-            log = "endpoint: .postFeed\n[POST] \(url)\n\n작성 성공\n내용: \(contentText.prefix(50))\n스포일러: \(isSpoiler) | 비공개: \(isPrivate)\n이미지: \(imageDatas.count)장"
+            log = "endpoint: .postFeed\n[POST] \(url)\n\n작성 성공\n내용: \(contentText.prefix(50))\n스포일러: \(isSpoiler) | 비공개: \(isPrivate)\n이미지: \(imageDatas.count)장\(compressionLog)"
             selectedItems = []
             selectedImageDatas = []
         } catch {
@@ -366,16 +366,49 @@ struct FeedDataDemoView: View {
         )
         let imageDatas = selectedImageDatas
         let url = "/feeds/\(feedID.value)"
+        let compressionLog = await makeCompressionLog(for: imageDatas)
         feedIDText = ""
         isLoading = true; defer { isLoading = false }
         do {
             try await repository.editFeed(id: feedID, draft: draft, imageDatas: imageDatas)
-            log = "endpoint: .patchFeed(feedID: \(feedID.value))\n[PUT] \(url)\n\n수정 성공\n내용: \(contentText.prefix(50))\n이미지: \(imageDatas.count)장"
+            log = "endpoint: .patchFeed(feedID: \(feedID.value))\n[PUT] \(url)\n\n수정 성공\n내용: \(contentText.prefix(50))\n이미지: \(imageDatas.count)장\(compressionLog)"
             selectedItems = []
             selectedImageDatas = []
         } catch {
             log = "endpoint: .patchFeed(feedID: \(feedID.value))\n[PUT] \(url)\n\n수정 실패\n\(error)"
         }
+    }
+
+    // MARK: - Compression Log (Demo 전용 관찰)
+
+    /// 업로드 직전 압축 전/후 크기를 측정해 로그 문자열로 만듭니다.
+    ///
+    /// 실제 업로드는 Repository가 자체 압축하므로, 여기서는 동일한 기본 정책으로
+    /// 다시 압축해 크기만 관찰합니다. (Demo 검증 목적)
+    private func makeCompressionLog(for imageDatas: [Data]) async -> String {
+        guard !imageDatas.isEmpty else { return "" }
+
+        let compressor = ImageCompressor()
+        let compressed = await compressor.compress(imageDatas)
+
+        let originalTotal = imageDatas.reduce(0) { $0 + $1.count }
+        let compressedTotal = compressed.reduce(0) { $0 + $1.count }
+
+        var lines = ["", "── 압축 결과 ──"]
+        for (index, original) in imageDatas.enumerated() {
+            let after = index < compressed.count ? compressed[index].count : original.count
+            lines.append("이미지 \(index + 1): \(formatBytes(original.count)) → \(formatBytes(after))")
+        }
+        lines.append("합계: \(formatBytes(originalTotal)) → \(formatBytes(compressedTotal))")
+        return lines.joined(separator: "\n")
+    }
+
+    private func formatBytes(_ bytes: Int) -> String {
+        let kb = Double(bytes) / 1024.0
+        if kb < 1024 {
+            return String(format: "%.1fKB", kb)
+        }
+        return String(format: "%.2fMB", kb / 1024.0)
     }
 
     private func deleteFeed() async {

--- a/Projects/Data/FeedData/Sources/ImageCompressor/ImageCompressor.swift
+++ b/Projects/Data/FeedData/Sources/ImageCompressor/ImageCompressor.swift
@@ -1,0 +1,152 @@
+//
+//  ImageCompressor.swift
+//  FeedData
+//
+//  Created by Lee Wonsun on 6/4/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// 피드 업로드용 이미지 압축 정책입니다.
+///
+/// 서버 스펙(이미지당 최대 용량)을 충족시키기 위해 다운샘플과 JPEG 품질을 조정합니다.
+public struct ImageCompressionPolicy: Sendable {
+    /// 이미지 한 장의 목표 최대 바이트 수입니다. (서버 스펙 기준)
+    public let maxByteSize: Int
+    /// 긴 변의 최대 픽셀 수입니다. 이보다 크면 다운샘플합니다.
+    public let maxPixelSize: CGFloat
+    /// JPEG 품질 하한선입니다. 이진 탐색이 이 값 아래로는 내려가지 않습니다.
+    public let minQuality: CGFloat
+
+    public init(maxByteSize: Int, maxPixelSize: CGFloat, minQuality: CGFloat) {
+        self.maxByteSize = maxByteSize
+        self.maxPixelSize = maxPixelSize
+        self.minQuality = minQuality
+    }
+
+    /// 피드 기본 정책입니다. `maxByteSize`는 V1 서버 스펙(512 * 512 = 256KB)을 그대로 사용합니다.
+    public static let feedDefault = ImageCompressionPolicy(
+        maxByteSize: 512 * 512,
+        maxPixelSize: 1920,
+        minQuality: 0.1
+    )
+}
+
+/// `Data → Data` 이미지 압축기입니다.
+///
+/// `UIImage` 디코딩 없이 ImageIO로 직접 처리하여 메모리 사용을 최소화합니다.
+/// 처리 순서는 ① 다운샘플 1회 → ② JPEG 품질 이진 탐색입니다.
+public struct ImageCompressor: Sendable {
+    private let policy: ImageCompressionPolicy
+
+    public init(policy: ImageCompressionPolicy = .feedDefault) {
+        self.policy = policy
+    }
+
+    /// 여러 이미지를 병렬로 압축합니다. 입력 순서를 보존합니다.
+    ///
+    /// 압축에 실패한 이미지는 원본 데이터를 그대로 반환합니다.
+    public func compress(_ imageDatas: [Data]) async -> [Data] {
+        await withTaskGroup(of: (Int, Data).self) { group in
+            for (index, data) in imageDatas.enumerated() {
+                group.addTask {
+                    (index, self.compress(data))
+                }
+            }
+
+            var results = [Data?](repeating: nil, count: imageDatas.count)
+            for await (index, data) in group {
+                results[index] = data
+            }
+            return results.compactMap { $0 }
+        }
+    }
+
+    /// 단일 이미지를 압축합니다. 실패 시 원본을 그대로 반환합니다.
+    public func compress(_ data: Data) -> Data {
+        guard let cgImage = downsampledImage(from: data) else { return data }
+        return compressedJPEG(from: cgImage) ?? data
+    }
+}
+
+// MARK: - Downsampling
+
+private extension ImageCompressor {
+    /// 긴 변이 `maxPixelSize`를 넘지 않도록 다운샘플한 CGImage를 생성합니다.
+    ///
+    /// 원본 비트맵 전체를 메모리에 펼치지 않고 썸네일 크기만 디코딩합니다.
+    func downsampledImage(from data: Data) -> CGImage? {
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+            return nil
+        }
+
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: policy.maxPixelSize
+        ] as CFDictionary
+
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions)
+    }
+}
+
+// MARK: - JPEG Encoding
+
+private extension ImageCompressor {
+    /// 목표 바이트 이하가 되도록 JPEG 품질을 이진 탐색하여 인코딩합니다.
+    ///
+    /// 가장 작으면서 목표를 만족하는 결과를 우선하되, 끝내 목표를 못 맞추면
+    /// 탐색 중 가장 작았던 결과(`minQuality`까지)를 반환합니다.
+    func compressedJPEG(from cgImage: CGImage) -> Data? {
+        var low = policy.minQuality
+        var high: CGFloat = 1.0
+        var bestUnderLimit: Data?
+        var smallestData: Data?
+
+        // 품질 1.0 결과가 이미 목표 이하면 추가 탐색 없이 사용합니다.
+        if let initialData = encodeJPEG(cgImage, quality: 1.0),
+           initialData.count <= policy.maxByteSize {
+            return initialData
+        }
+
+        // 이진 탐색: 목표를 만족하는 가장 높은 품질을 찾습니다.
+        for _ in 0..<8 {
+            let mid = (low + high) / 2
+            guard let data = encodeJPEG(cgImage, quality: mid) else { break }
+
+            if smallestData.map({ data.count < $0.count }) ?? true {
+                smallestData = data
+            }
+
+            if data.count <= policy.maxByteSize {
+                bestUnderLimit = data
+                low = mid
+            } else {
+                high = mid
+            }
+        }
+
+        return bestUnderLimit ?? smallestData
+    }
+
+    func encodeJPEG(_ cgImage: CGImage, quality: CGFloat) -> Data? {
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else { return nil }
+
+        let properties = [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary
+        CGImageDestinationAddImage(destination, cgImage, properties)
+
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+}

--- a/Projects/Data/FeedData/Sources/Repository/DefaultFeedRepository.swift
+++ b/Projects/Data/FeedData/Sources/Repository/DefaultFeedRepository.swift
@@ -16,28 +16,32 @@ public struct DefaultFeedRepository: FeedRepository {
     private let service: FeedService
     private let logger: DataLogger?
     private let storage: AppStorage
+    private let imageCompressor: ImageCompressor
     private let pageSize = 20
 
     init(
         service: FeedService,
         logger: DataLogger? = nil,
-        storage: AppStorage = UserDefaultsStorage()
+        storage: AppStorage = UserDefaultsStorage(),
+        imageCompressor: ImageCompressor = ImageCompressor()
     ) {
         self.service = service
         self.logger = logger
         self.storage = storage
+        self.imageCompressor = imageCompressor
     }
 
     public func submitFeed(_ draft: FeedDraft, imageDatas: [Data]) async throws(RepositoryError) {
         let action = FeedAction.submitFeed
 
+        let compressedImageDatas = await imageCompressor.compress(imageDatas)
         let request = SubmitFeedRequest(
             feedContent: draft.content,
             relevantCategories: draft.genre.map { FeedMapper.genreString(from: $0) },
             novelId: draft.connectedNovel?.id.value,
             isSpoiler: draft.isSpoiler,
             isPublic: !draft.isPrivate,
-            imageDatas: imageDatas
+            imageDatas: compressedImageDatas
         )
         do {
             _ = try await service.postFeed(request: request)
@@ -53,13 +57,15 @@ public struct DefaultFeedRepository: FeedRepository {
 
     public func editFeed(id: FeedID, draft: FeedDraft, imageDatas: [Data]) async throws(RepositoryError) {
         let action = FeedAction.editFeed
+
+        let compressedImageDatas = await imageCompressor.compress(imageDatas)
         let request = SubmitFeedRequest(
             feedContent: draft.content,
             relevantCategories: draft.genre.map { FeedMapper.genreString(from: $0) },
             novelId: draft.connectedNovel?.id.value,
             isSpoiler: draft.isSpoiler,
             isPublic: !draft.isPrivate,
-            imageDatas: imageDatas
+            imageDatas: compressedImageDatas
         )
         do {
             _ = try await service.patchFeed(feedID: id.value, request: request)

--- a/Projects/Data/FeedData/Tests/DefaultFeedRepositoryTests.swift
+++ b/Projects/Data/FeedData/Tests/DefaultFeedRepositoryTests.swift
@@ -33,9 +33,10 @@ struct DefaultFeedRepositoryTests {
         #expect(service.postedRequests[0].imageDatas == [])
     }
 
-    @Test("submitFeed 성공 시 imageDatas가 service로 그대로 전달된다")
-    func submitFeed_success_passesImageDatasToService() async throws {
+    @Test("submitFeed 시 디코딩 불가한 데이터는 압축기를 거쳐도 원본 그대로 전달된다")
+    func submitFeed_nonImageData_passesThroughUncompressed() async throws {
         let (sut, service) = makeRepository()
+        // 이미지로 디코딩되지 않는 데이터는 압축기가 원본을 그대로 반환한다.
         let imageDatas = [Data("image1".utf8), Data("image2".utf8)]
 
         try await sut.submitFeed(makeDraft(), imageDatas: imageDatas)
@@ -58,6 +59,7 @@ struct DefaultFeedRepositoryTests {
     @Test("editFeed 성공 시 올바른 feedID와 request로 service 호출")
     func editFeed_success_callsServiceWithCorrectParams() async throws {
         let (sut, service) = makeRepository()
+        // 이미지로 디코딩되지 않는 데이터는 압축기가 원본을 그대로 반환한다.
         let imageDatas = [Data("edited".utf8)]
 
         try await sut.editFeed(id: FeedID(10), draft: makeDraft(content: "수정된 피드"), imageDatas: imageDatas)

--- a/Projects/Data/FeedData/Tests/ImageCompressorTests.swift
+++ b/Projects/Data/FeedData/Tests/ImageCompressorTests.swift
@@ -1,0 +1,117 @@
+//
+//  ImageCompressorTests.swift
+//  FeedDataTests
+//
+//  Created by Lee Wonsun on 6/4/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import Testing
+import UIKit
+@testable import FeedData
+
+@Suite
+struct ImageCompressorTests {
+
+    // MARK: - 정상 케이스
+
+    @Test("목표 바이트를 초과하는 이미지는 목표 이하로 압축된다")
+    func compress_largeImage_resultIsUnderMaxByteSize() async throws {
+        let policy = ImageCompressionPolicy(maxByteSize: 256 * 1024, maxPixelSize: 1024, minQuality: 0.1)
+        let sut = ImageCompressor(policy: policy)
+        let largeImageData = try #require(makeNoisyImageData(size: 2000))
+
+        let compressed = sut.compress(largeImageData)
+
+        #expect(compressed.count <= policy.maxByteSize)
+        #expect(compressed.count < largeImageData.count)
+    }
+
+    @Test("이미 목표 바이트 이하인 이미지는 더 키우지 않는다")
+    func compress_smallImage_doesNotGrow() async throws {
+        let policy = ImageCompressionPolicy(maxByteSize: 5 * 1024 * 1024, maxPixelSize: 1920, minQuality: 0.1)
+        let sut = ImageCompressor(policy: policy)
+        let smallImageData = try #require(makeSolidImageData(size: 50))
+
+        let compressed = sut.compress(smallImageData)
+
+        #expect(compressed.count <= policy.maxByteSize)
+        #expect(!compressed.isEmpty)
+    }
+
+    // MARK: - 경계값 / 정책 위반 케이스
+
+    @Test("이미지로 디코딩되지 않는 데이터는 원본을 그대로 반환한다")
+    func compress_nonImageData_returnsOriginal() async {
+        let sut = ImageCompressor()
+        let garbage = Data("not an image".utf8)
+
+        let result = sut.compress(garbage)
+
+        #expect(result == garbage)
+    }
+
+    @Test("빈 입력 배열은 빈 결과를 반환한다")
+    func compress_emptyArray_returnsEmpty() async {
+        let sut = ImageCompressor()
+
+        let result = await sut.compress([Data]())
+
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - 상태/순서 검증
+
+    @Test("여러 이미지를 압축해도 입력 순서가 보존된다")
+    func compress_multipleImages_preservesOrder() async throws {
+        let sut = ImageCompressor()
+        // 디코딩 불가한 데이터는 원본 그대로 반환되므로 순서 검증에 사용한다.
+        let inputs = [
+            Data("first".utf8),
+            Data("second".utf8),
+            Data("third".utf8)
+        ]
+
+        let result = await sut.compress(inputs)
+
+        #expect(result == inputs)
+    }
+}
+
+// MARK: - Helpers
+
+private extension ImageCompressorTests {
+
+    /// 단색 이미지는 JPEG로 매우 작게 압축되므로 "작은 이미지" 케이스에 사용한다.
+    func makeSolidImageData(size: CGFloat) -> Data? {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+        let image = renderer.image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: size, height: size))
+        }
+        return image.jpegData(compressionQuality: 1.0)
+    }
+
+    /// 노이즈가 많은 이미지는 JPEG 압축이 잘 안 되어 용량이 커지므로 "큰 이미지" 케이스에 사용한다.
+    func makeNoisyImageData(size: CGFloat) -> Data? {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+        let image = renderer.image { context in
+            let step: CGFloat = 4
+            var y: CGFloat = 0
+            var seed: UInt64 = 0x9E3779B97F4A7C15
+            while y < size {
+                var x: CGFloat = 0
+                while x < size {
+                    seed = seed &* 6364136223846793005 &+ 1442695040888963407
+                    let hue = CGFloat((seed >> 33) & 0xFF) / 255.0
+                    UIColor(hue: hue, saturation: 1, brightness: 1, alpha: 1).setFill()
+                    context.fill(CGRect(x: x, y: y, width: step, height: step))
+                    x += step
+                }
+                y += step
+            }
+        }
+        return image.jpegData(compressionQuality: 1.0)
+    }
+}


### PR DESCRIPTION
  ## 💡 Issue                                 
  <!-- closed #1 -->                          
  #134                                    
  <br>                                                                                                                                                                           
                                                                                                                                                                                 
  ## 💭 Summary                                                                                                                                                                  
  <!-- 작업에 대한 간단한 소개 -->                                                                                                                                               
                                                                                                                                                                                 
  피드 업로드 직전 클라이언트 사이드 이미지 압축 도구(`ImageCompressor`)를 도입합니다.
                                          
  서버 스펙(이미지당 최대 **256KB**) 충족을 위해 V1의 `UIImage` 기반 블로킹 + 선형 탐색을, **ImageIO 기반 `Data → Data` 변환 + 다운샘플 + JPEG 품질 이진 탐색** 방식으로         
  교체했습니다.                                                                                                                                                                  
                                                                                                                                                                                 
  <br>                                                                                                                                                                           
                                                                                                                                      
  ## 🔑 Key Changes                                                                                                                                                              
  <!-- 작업에 대한 구체적인 설명 -->                                                                                                  

  ### 🎯 핵심 결정: `UIImage` 우회 + `Data → Data`
                                          
  **V1 흐름 (UIImage 경유) — 제거됨**
  ```                                                                                                                                                                            
  원본 Data
    → UIImage.init(data:)              ← 전체 비트맵 디코딩 (메모리에 펼침)                                                                                                      
    → UIGraphicsImageRenderer로 재드로잉                                                                                              
    → image.jpegData(compressionQuality:)     
  ```                                     
  - `UIImage(data:)` 시점에 **원본 전체 비트맵이 메모리에 풀림**                                                                                                                 
    - 3000×3000 RGBA = `3000 × 3000 × 4 ≈ 34MB`                                                                                                                                  
    - 5장 동시 처리 시 추가 ~170MB → OOM 위험                                                                                                                                    
  - `UIGraphicsImageRenderer` 재드로잉으로 한 번 더 비트맵 생성                                                                                                                  
  - `UIImage` 라이프사이클이 묶여 테스트 / 백그라운드 처리 까다로움                                                                                                              
                                              
  **새 흐름 (ImageIO 직접)**        
  > 💡 **ImageIO란?**                                                                                                                                                            
  > Apple의 시스템 프레임워크입니다 (`import ImageIO`). iOS / macOS / tvOS / watchOS / visionOS 모두에서 **추가 의존성 없이** 사용 가능해요.                                     
  > - 이미지 디코딩 / 인코딩 (JPEG, PNG, HEIC, GIF, RAW…)                                                                                                                        
  > - 메타데이터(EXIF / IPTC) 처리                                                                                                                                               
  > - 다운샘플(썸네일) / 색공간 변환                                                                                                             
  > - `CGImageSource`, `CGImageDestination`, `CGImage` 같은 Core Graphics 타입과 함께 동작                                                                                       
  >                                                                                                                                                                              
  > `UIImage(data:)`도 내부적으로 ImageIO를 호출합니다. 이번 작업은 **UIKit 추상화를 한 겹 벗고 같은 엔진(ImageIO)을 직접 사용**한 것이라, 추가 의존성 0이면서 UIKit 추상화로    
  발생하던 전체 비트맵 디코딩 비용을 피합니다.     
                                                                                                                                             
  ```                                                                                                                                 
  원본 Data                                                                                                                                                                      
    → CGImageSourceCreateWithData              ← 메타데이터만 읽음                                                                    
    → CGImageSourceCreateThumbnailAtIndex      ← 다운샘플 크기만 디코딩                                                                                                          
         (maxPixelSize: 1920, shouldCache: false)                                                                                     
    → CGImageDestinationCreateWithData(.jpeg, quality)                                                                                                                           
  ```                                         
  - `kCGImageSourceShouldCache: false` + `kCGImageSourceThumbnailMaxPixelSize: 1920`                                                                                             
    - **원본 전체 비트맵을 안 펼침** — 다운샘플된 결과만 디코딩                                                                       
    - 3000×3000 원본도 1920×1920 썸네일(~14MB)만 메모리 점유                                                                                                                     
  - `UIImage` 라이프사이클 없는 순수 `Data → Data` 변환                                                                               
                                                                                                                                                                                 
  ### 🆚 다른 다운샘플 방식과의 비교                                                                                                                                             
                                                                                                                                                                                 
  iOS에서 이미지 리사이즈/압축 시 선택지는 여러 가지가 있습니다. 각 방식의 특성과 본 PR이 ImageIO를 택한 이유:                                                                   
                                                                                                                                                                                 
  | 방식 | 메모리 | 속도 | 화질 | 구현 난이도 | 특징 |                                                                                                                           
  |------|:------:|:----:|:----:|:----------:|------|                                                                                                                            
  | **ImageIO 다운샘플 (현재)** | ★★★★★ | ★★★★ | ★★★ | ★ | 원본 디코딩 회피 |
  | UIImage + UIGraphicsImageRenderer | ★ | ★★ | ★★★ | ★ | 가장 쉽지만 비트맵 펼침 |                                                                                             
  | UIImage + Core Graphics(`CGContext`) | ★★ | ★★★ | ★★★ | ★★ | UIImage 경유 한계 동일 |                                                        
  | Core Image (`CILanczosScaleTransform`) | ★★ | ★★★★ (GPU) | ★★★★★ | ★★★ | 화질 최상, 셋업 비용 |                                                                              
  | vImage (Accelerate) | ★★★★ | ★★★★★ | ★★★ | ★★★★ | SIMD 대량 처리에 강점 |                                                                                                    
  | Metal / MPS | ★★★ | ★★★★★ | ★★★ | ★★★★★ | 실시간 GPU 파이프라인용 |                                                                                                          
                                                                                                                                                                                 
  > ★는 상대적 비교 추정치입니다.                                                                                                                                                
                                                                                                                                                                                 
  **ImageIO 다운샘플의 핵심 장점**                                                                                                                                               
                                                                                                                                                                                 
  1. **원본 비트맵을 메모리에 안 펼침**                                                                                               
     - `kCGImageSourceShouldCache: false`로 메타데이터만 읽고, `CGImageSourceCreateThumbnailAtIndex`가 **다운샘플된 결과만 디코딩**
     - UIImage/CGContext/Core Image는 모두 원본 전체 디코딩이 선행됨
  2. **단일 호출** — 함수 한 번으로 디코딩 + 다운샘플 동시 완료                                                                                                                  
  3. **EXIF orientation 자동 처리** — `kCGImageSourceCreateThumbnailWithTransform: true`로 회전 정보를 따로 보정할 필요 없음
  4. **포맷 자동 분기** — JPEG / PNG / HEIC / RAW 등 동일 API                                                                                                                    
  5. **외부 의존성 0** — Apple 시스템 프레임워크 (`import ImageIO`만)                                                                                                            
  6. **백그라운드 친화** — Core Graphics 기반이라 `withTaskGroup` 병렬 처리와 자연스럽게 맞물림                                                                                                            
                                              
  ### ⚙️  동작 순서                                                                                                                                                               
                                                                                                                                                                                 
  ```                                                                                                                                                                            
  ① 다운샘플 1회                ← 가장 비싼 작업 한 번만                                                                                                                         
     maxPixelSize: 1920 (긴 변 기준)                                                                                                                                             
                                                                                                                                      
  ② JPEG 품질 이진 탐색         ← maxByteSize 이하 만족하는 가장 높은 품질
     범위: [minQuality(0.1), 1.0]                                                                                                                                                
     - quality 1.0이 이미 목표 이하면 즉시 사용
     - 그 외엔 8회 이진 탐색                                                                                                                                                     
     - 끝까지 못 맞추면 탐색 중 가장 작았던 결과 fallback                                                                                                                        
  ```                                         
                                                                                                                                                                                 
  ### 🛡 핵심 보장: 항상 `Data` 반환 (throw 없음)                                                                                      
                                                                                                                                                                                 
  ```swift                                                                                                                            
  public func compress(_ data: Data) -> Data {                                                                                                                                   
      guard let cgImage = downsampledImage(from: data) else { return data }                                                           
      return compressedJPEG(from: cgImage) ?? data                                                                                                                               
  }                                           
  ```                                                                                                                                                                            
  - 디코딩 실패(비-이미지, 손상 파일 등) → **원본 그대로 반환**                                                                       
  - `throws` 없음 → Repository에서 do-catch 없이 한 줄 호출                                                                                                                      
  - 테스트에서 dummy `Data`로 시그니처 / 순서 검증 가능
                                                                                                                                                                                 
  ### 📐 정책 (`ImageCompressionPolicy.feedDefault`)                                                                                  
                                                                                                                                                                                 
  | 파라미터 | 값 | 의미 |                                                                                                                                                       
  |---------|----|----|                                                                                                                                                          
  | `maxByteSize` | `512 * 512` (256KB) | V1 서버 스펙 그대로 유지 |                                                                                                             
  | `maxPixelSize` | `1920` | 긴 변 최대 픽셀 (Full HD 수준) |                                                                        
  | `minQuality` | `0.1` | 품질 이진 탐색 하한 |
                                                                                                                                                                                 
  ### 📍 적용 지점                        
                                                                                                                                                                                 
  - `DefaultFeedRepository.submitFeed`                                                                                                                                           
  - `DefaultFeedRepository.editFeed`                                                                                                                                             
                                                                                                                                                                                 
  UseCase / Endpoint / Service 시그니처는 그대로(`imageDatas: [Data]`). **압축은 Repository 책임으로 격리** → 도메인/상위 레이어에 노출되지 않음.                                             
                                                                                                                                                                                 
  <br>                                                                                                                                                                           
                                                                                                                                                                                 
  ## 📱 Simulation                                                                                                                                                                                                                                                                                      
          
<img width="250" alt="Simulator Screen Recording - iPhone 17 - 2026-06-04 at 20 19 16" src="https://github.com/user-attachments/assets/857765b8-2d23-4609-9f8b-8b0654d603a4" />                                                                                                                                                                       
                                                                                                                                                                                 
  <br>                                                                                                                                                                           
                                                                                                                                                                                 
  ## ※ Reference                                                                                                                                                                 
  <!-- 작업 시 참고한 레퍼런스 -->                                                                                                                                               
                                                                                                                                                                                 
  - WWDC 2018 — *Image and Graphics Best Practices* (ImageIO 다운샘플 패턴의 표준 레퍼런스)                                                                                      
  - Apple Docs — `CGImageSource` / `CGImageDestination`                                                                               
  - 사용 옵션: `kCGImageSourceCreateThumbnailFromImageAlways`, `kCGImageSourceThumbnailMaxPixelSize`, `kCGImageSourceShouldCache`