### PR TITLE
[Fix] #142 - WSSToggleButton 외부 값 변경에도 애니메이션 적용

### DIFF
--- a/Projects/UI/WSSComponent/Sources/Button/WSSToggleButton.swift
+++ b/Projects/UI/WSSComponent/Sources/Button/WSSToggleButton.swift
@@ -25,10 +25,9 @@ public struct WSSToggleButton: View {
                 .padding(padding)
         }
         .frame(width: width, height: height)
+        .animation(.spring(response: 0.25, dampingFraction: 1.0), value: isOn)
         .onTapGesture {
-            withAnimation(.spring(response: 0.25, dampingFraction: 1.0)) {
-                isOn.toggle()
-            }
+            isOn.toggle()
         }
     }
 }


### PR DESCRIPTION
## 💡 Issue
closed #142

<br>

## 💭 Summary
`WSSToggleButton`이 탭할 때만 애니메이션이 동작하고, 외부에서 `isOn` 바인딩을 프로그래밍적으로 변경하면 애니메이션 없이 즉시 점프하던 문제를 수정했습니다. 이제 값이 어떤 경로로 바뀌든 컴포넌트가 항상 애니메이션을 적용합니다.

<br>

## 🔑 Key Changes
- `onTapGesture` 내부의 `withAnimation(...)`을 제거하고, 컴포넌트 View에 `.animation(.spring(response: 0.25, dampingFraction: 1.0), value: isOn)` 모디파이어를 부착
- `isOn` 값 변화 자체를 SwiftUI가 감시·애니메이트하므로, 탭/외부 바인딩 변경 모두 동일하게 동작
- 호출 측에서 `withAnimation`으로 감쌀 필요 없음 (스프링 파라미터는 기존과 동일하게 유지)

<br>

## 📱 Simulation
<!-- 토글 동작 영상/캡처 첨부 예정 -->

<br>


<br>

## ※ Reference
-