### PR TITLE
[Fix] #184 - 토큰 재발급 중복 요청으로 세션이 끊기는 현상 수정

### DIFF
--- a/.claude/scripts/ready-merge.sh
+++ b/.claude/scripts/ready-merge.sh
@@ -70,13 +70,20 @@ cmd_rebase() {
 
   git fetch origin "$base" || die "git fetch origin '$base' 실패."
 
-  if git rebase "origin/$base"; then
+  # ⚠️ rebase 동안 git 훅을 끈다(`core.hooksPath=/dev/null`).
+  # rebase는 내부적으로 base를 체크아웃하는데, 그걸 브랜치 전환으로 본 `.githooks/post-checkout`이
+  # `tuist generate`를 돌린다. 10초 넘게 걸리는 그 작업이 커밋 적용과 겹치면
+  # "Your local changes would be overwritten by merge"로 rebase가 죽는다(워킹트리는 clean이었는데도).
+  # 프로젝트 재생성은 rebase가 끝난 뒤 한 번 하면 된다.
+  if git -c core.hooksPath=/dev/null rebase "origin/$base"; then
     echo "REBASE=OK"
   else
     echo "REBASE=CONFLICT"
     echo "── 충돌 파일 ──" >&2
     git diff --name-only --diff-filter=U >&2 || true
-    echo "해결 후: git add <파일> && git rebase --continue   /   중단: git rebase --abort" >&2
+    # continue도 훅을 꺼서 이어간다 — 위와 같은 이유(post-checkout의 tuist generate).
+    echo "해결 후: git add <파일> && git -c core.hooksPath=/dev/null rebase --continue" >&2
+    echo "중단: git rebase --abort   /   rebase 후 프로젝트 재생성: tuist generate" >&2
     exit 2
   fi
 }
@@ -98,6 +105,10 @@ cmd_build_all() {
   else
     echo "BUILD_ALL=FAIL"
     echo "위 xcodebuild 출력에서 실패한 scheme/파일을 확인하세요(tuist build는 첫 실패 지점에서 멈춥니다)." >&2
+    # ⚠️ 코드가 멀쩡해도 여기로 온다 — 시뮬레이터 이름이 이 머신에 없으면 첫 스킴에서
+    # "Could not find a suitable device ... Did find ..."로 죽는다(기본값 "iPhone 17"은 머신마다 없을 수 있다).
+    echo "⚠️ 출력이 \"Could not find a suitable device\"면 코드 문제가 아니라 시뮬레이터 이름 문제입니다 —" >&2
+    echo "   그 메시지의 'Did find' 목록에서 골라 인자로 넘기세요: ready-merge.sh build-all \"iPhone 17 Pro\"" >&2
     exit 1
   fi
 }

--- a/.claude/skills/ready-merge/SKILL.md
+++ b/.claude/skills/ready-merge/SKILL.md
@@ -31,7 +31,12 @@ PR을 올린 뒤, 머지 직전에 작업 브랜치를 **최신 `develop` 위로
 - `bash .claude/scripts/ready-merge.sh rebase develop`
   - **`REBASE=OK`**: 깔끔히 올라갔다 → 3단계로.
   - **`REBASE=CONFLICT`(exit 2)**: 스크립트가 충돌 파일을 출력하고 멈춘다. 충돌을 **사용자와 함께 해결**한다:
-    - 충돌 내용을 확인·해결한다(메인이 도울 수 있음) → `git add <해결한 파일>` → `git rebase --continue`.
+    - 충돌 내용을 확인·해결한다(메인이 도울 수 있음) → `git add <해결한 파일>` →
+      **`git -c core.hooksPath=/dev/null rebase --continue`**.
+      ⚠️ **`--continue`도 훅을 꺼야 한다** — rebase가 base를 체크아웃하는 걸 브랜치 전환으로 본
+      `.githooks/post-checkout`이 `tuist generate`(10초+)를 돌리고, 그게 커밋 적용과 겹치면
+      워킹트리가 clean이었는데도 *"Your local changes would be overwritten by merge"* 로 죽는다.
+      (스크립트의 `rebase`는 이미 훅을 끄고 부른다. **rebase가 끝난 뒤 `tuist generate`를 한 번** 실행할 것.)
     - 커밋이 여럿이면 충돌이 여러 번 날 수 있다 — rebase가 끝날 때까지 반복한다.
     - 중단하려면 `git rebase --abort`(원래 상태로 복귀) 후 종료한다.
   - rebase가 끝나면(`git status`로 rebase 진행 중이 아님을 확인) 3단계로.

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -7,6 +7,12 @@
 # 또는 매니페스트 변경이 있으면 재생성이 필요하다(단순 내용 수정은 불필요).
 #
 # 활성화: git config core.hooksPath .githooks  (클론 후 1회)
+#
+# ⚠️ rebase 중에는 이 훅을 꺼야 한다. rebase는 base를 체크아웃하는데 그게 브랜치 전환($3=1)으로
+# 잡혀 여기서 tuist generate(10초+)가 돌고, 커밋 적용과 겹치면 워킹트리가 clean이었는데도
+# "Your local changes would be overwritten by merge"로 rebase가 죽는다.
+#   git -c core.hooksPath=/dev/null rebase <base>   (ready-merge.sh가 이렇게 부른다)
+# rebase가 끝난 뒤 tuist generate를 한 번 실행하면 된다.
 set -e
 
 prev="$1"; new="$2"; branch_flag="$3"

--- a/Projects/Core/Networking/CLAUDE.md
+++ b/Projects/Core/Networking/CLAUDE.md
@@ -60,5 +60,5 @@ refresh token이 1회용이라, 재발급이 동시에 두 번 나가면 나중 
 - ⚠️ **토큰 갱신 요청 자체의 Endpoint는 `authorization = .withoutToken`** 이어야 한다 (프로토콜 주석). 안 그러면 갱신→401→갱신 무한 루프.
 - ⚠️ **`SessionRefreshCoordinator.refresh()`의 "검사 → `inFlight` 저장" 구간에 `await`를 넣지 말 것.** actor는 함수 전체를 잠그지 않고 `await`마다 양보하므로, 그 사이에 suspend가 끼면 두 호출이 모두 "진행 중 없음"을 보고 각자 재발급을 시작한다 — 고친 버그가 그대로 부활한다.
 - ⚠️ **인증이 필요한 `NetworkingClient`는 앱 전체에서 하나를 공유**해야 한다. coordinator가 client마다 하나씩 생기므로, client를 화면·모듈마다 새로 만들면 재발급 직렬화가 무의미해진다. (조립부를 만들 때 반드시 지킬 것 — 현재 Demo들은 각자 client를 만든다.)
-- `inFlight` 정리는 재발급 Task 자신의 `defer`가 전담한다 — 그래서 "남의 Task를 지우는" 경우가 없어 세대 가드가 필요 없다. **정리를 대기자 쪽으로 옮기면 즉시 필요해진다.**
+- ⚠️ **`inFlight` 정리는 재발급 Task 자신의 `defer`가 전담한다 — 대기자 쪽(`await task.value` 뒤)으로 옮기지 말 것.** 거기서만 비워지므로 "남의 Task를 지우는" 경우가 원천적으로 없다. 대기자는 여럿이라 늦게 깬 쪽이 그 사이 시작된 새 Task를 지울 수 있고, 그걸 막으려면 세대 카운터 같은 곁가지 상태가 붙는다. **정리 위치를 지키는 것이 그 복잡도를 통째로 없애는 조건**이므로, 옮기고 가드를 더하는 방향으로 가지 않는다.
 - 도메인을 모른다 — `NetworkingError`를 `RepositoryError`로 바꾸는 건 BaseData(`toRepositoryError()`) 책임. 여기서 하지 말 것.

--- a/Projects/Core/Networking/CLAUDE.md
+++ b/Projects/Core/Networking/CLAUDE.md
@@ -51,14 +51,37 @@ refresh token이 1회용이라, 재발급이 동시에 두 번 나가면 나중 
 
 1. **coalescing** — 진행 중인 재발급 Task를 공유한다(동시 401 N건 → 재발급 1회).
 2. **토큰 세대 비교** — 요청이 쓴 access token이 저장소의 것과 다르면 이미 남이 갱신한 것이므로 **재발급 없이** 새 토큰으로 재시도한다. coalescing만으로는 "갱신 직후 도착한 401"을 못 잡는다.
-3. **세션 종료 판정 분리** — refresher가 **4xx로 실패할 때만** 세션 종료로 보고 토큰을 지운다. 통신 실패는 에러를 그대로 전파해 토큰을 보존한다.
+3. **재발급 실패 판정 3분화** — 실패를 셋으로 갈라 처리한다(`SessionRefreshCoordinator`).
+
+| refresher가 실패한 방식 | 토큰 | 상위로 나가는 것 |
+|---|---|---|
+| `responseFailure(401)` — 서버가 refresh token 자체를 거절 | **삭제** | `requiresReauthentication` |
+| `responseFailure(그 밖의 모든 status)` — 응답은 왔으나 갱신 실패 | **보존** | `requiresReauthentication` |
+| `decoding` — 200인데 응답 스키마가 깨짐 | **보존** | `requiresReauthentication` |
+| 그 밖의 전부(통신 실패·타임아웃·클라이언트 버그) | 보존 | 원래 에러 그대로 전파 |
+
+status를 열거하지 않는다 — 코드(`isRefreshRejected`)도 `responseFailure`면 코드값을 보지 않고,
+**토큰 삭제 여부에서만 401을 가른다.** `403`·`429`처럼 표에 없는 응답도 재인증으로 간다.
+
+- **새 토큰을 못 받은 게 확정이면 재인증으로 보낸다** — 갱신이 안 되는 토큰으로 앱을 계속 쓰게 두면 401만 반복된다.
+  `decoding`이 여기 끼는 이유: 200이어도 파싱에 실패하면 **저장된 토큰은 낡은 그대로**라 결과가 같다.
+  ⚠️ 이때 **재발급 쪽 에러를 그대로 던지면 안 된다.** 위로 나가면 원 요청이 실패한 것처럼 보여
+  `toRepositoryError()`가 `/reissue`의 404를 `.notFound`로 바꾸고, 화면이 "없는 리소스"로 오해한다.
+- **토큰 삭제는 401뿐** — 5xx 같은 일시적 장애에서 지우면 서버가 복구돼도 세션을 되살릴 수 없다.
+- **통신 실패는 세션 상태를 증명하지 않는다** — 여기서 로그아웃시키면 지하철에서 잠깐 끊겼다고 튕긴다(#184 이전 버그).
 
 재시도는 요청당 최대 2회(`NetworkingClient.maxAuthRetries`)이며, 카운터를 줄이며 `request`로 재귀해 무한 루프를 막는다.
+⚠️ **1회로 줄이면 안 된다** — 2번(토큰 세대 비교)으로 "남이 갱신해준 토큰으로 재시도"하는 것도 이 카운터를 한 번 쓴다.
+1회면 그 요청이 실제 재발급 기회를 잃고 401로 죽는다.
 
 ## 주의사항 (작업 중 발견 시 누적)
 
 - ⚠️ **토큰 갱신 요청 자체의 Endpoint는 `authorization = .withoutToken`** 이어야 한다 (프로토콜 주석). 안 그러면 갱신→401→갱신 무한 루프.
 - ⚠️ **`SessionRefreshCoordinator.refresh()`의 "검사 → `inFlight` 저장" 구간에 `await`를 넣지 말 것.** actor는 함수 전체를 잠그지 않고 `await`마다 양보하므로, 그 사이에 suspend가 끼면 두 호출이 모두 "진행 중 없음"을 보고 각자 재발급을 시작한다 — 고친 버그가 그대로 부활한다.
+- ⚠️ **탈퇴 유저(`404` + `USER-006`)는 위 표를 타지 않는다.** refresher도 `NetworkingClient`로 `/reissue`를 부르므로,
+  그 응답이 USER-006이면 **안쪽 client가 먼저 토큰을 지우고** `requiresReauthentication`을 던진다 → coordinator의
+  catch(`isRefreshRejected`)는 `responseFailure`가 아니라 그냥 통과시킨다. 결과(토큰 삭제 + 로그인)는 의도대로지만,
+  **"404는 토큰 보존"이라는 표만 보고 판단하면 어긋나 보인다.** 토큰을 지우는 자리가 두 곳이라는 걸 알고 볼 것.
 - ⚠️ **인증이 필요한 `NetworkingClient`는 앱 전체에서 하나를 공유**해야 한다. coordinator가 client마다 하나씩 생기므로, client를 화면·모듈마다 새로 만들면 재발급 직렬화가 무의미해진다. (조립부를 만들 때 반드시 지킬 것 — 현재 Demo들은 각자 client를 만든다.)
 - ⚠️ **`inFlight` 정리는 재발급 Task 자신의 `defer`가 전담한다 — 대기자 쪽(`await task.value` 뒤)으로 옮기지 말 것.** 거기서만 비워지므로 "남의 Task를 지우는" 경우가 원천적으로 없다. 대기자는 여럿이라 늦게 깬 쪽이 그 사이 시작된 새 Task를 지울 수 있고, 그걸 막으려면 세대 카운터 같은 곁가지 상태가 붙는다. **정리 위치를 지키는 것이 그 복잡도를 통째로 없애는 조건**이므로, 옮기고 가드를 더하는 방향으로 가지 않는다.
 - 도메인을 모른다 — `NetworkingError`를 `RepositoryError`로 바꾸는 건 BaseData(`toRepositoryError()`) 책임. 여기서 하지 말 것.

--- a/Projects/Core/Networking/CLAUDE.md
+++ b/Projects/Core/Networking/CLAUDE.md
@@ -8,11 +8,25 @@ HTTP 클라이언트 + 요청/응답 추상화. Data 레이어가 이걸로 통�
 ## 핵심 구조
 
 - `NetworkingRequestable.request(_ endPoint: Endpoint) async throws -> Data` — **raw `Data` 반환** (디코딩은 호출 측/Service 책임).
-- `Endpoint` 프로토콜: method/baseURL/path/queryItems/headers/body + **`requireTokenRefresh`** (401 시 토큰 갱신 시도 여부). `urlRequest` 기본 구현 제공.
-- `NetworkingError`: `invalidURL / decoding / responseFailure(code, body) / requiresReauthentication / unknown(Error)`.
+- `Endpoint` 프로토콜: method/baseURL/path/query/headers/body + **`authorization: AuthorizationPolicy`**(`requireToken` / `withoutToken` / `usesTokenIfAvailable`). `makeURLRequest()` 기본 구현 제공.
+- `NetworkingError`: `invalidURL / decoding / responseFailure(code, body) / requestEncodingFailed(Error) / requiresReauthentication / unknown(Error)`.
 - `AuthSessionRefreshing.refreshSession() async throws -> Bool` — 401 재인증 훅 (구현체는 AuthData의 `AuthSessionRefresher`).
+- `SessionRefreshCoordinator`(actor) — 401 재인증을 직렬화한다. `NetworkingClient`가 refresher를 받으면 내부에서 생성해 소유한다.
+
+## 401 재인증 흐름
+
+서버가 refresh token을 **회전**시키므로 재발급이 동시에 두 번 나가면 나중 것이 폐기된 토큰을 써서 세션 전체가 끊긴다. 이를 세 겹으로 막는다.
+
+1. **coalescing** — 진행 중인 재발급 Task를 공유한다(동시 401 N건 → 재발급 1회).
+2. **토큰 세대 비교** — 요청이 쓴 access token이 저장소의 것과 다르면 이미 남이 갱신한 것이므로 **재발급 없이** 새 토큰으로 재시도한다. coalescing만으로는 "갱신 직후 도착한 401"을 못 잡는다.
+3. **세션 종료 판정 분리** — refresher가 **4xx로 실패할 때만** 세션 종료로 보고 토큰을 지운다. 통신 실패는 에러를 그대로 전파해 토큰을 보존한다.
+
+재시도는 요청당 최대 2회(`NetworkingClient.maxAuthRetries`)이며, 카운터를 줄이며 `request`로 재귀해 무한 루프를 막는다.
 
 ## 주의사항 (작업 중 발견 시 누적)
 
-- ⚠️ **토큰 갱신 요청 자체의 Endpoint는 `requireTokenRefresh = false`** 여야 한다 (프로토콜 주석). 안 그러면 갱신→401→갱신 무한 루프.
+- ⚠️ **토큰 갱신 요청 자체의 Endpoint는 `authorization = .withoutToken`** 이어야 한다 (프로토콜 주석). 안 그러면 갱신→401→갱신 무한 루프.
+- ⚠️ **`SessionRefreshCoordinator.refresh()`의 "검사 → `inFlight` 저장" 구간에 `await`를 넣지 말 것.** actor는 함수 전체를 잠그지 않고 `await`마다 양보하므로, 그 사이에 suspend가 끼면 두 호출이 모두 "진행 중 없음"을 보고 각자 재발급을 시작한다 — 고친 버그가 그대로 부활한다.
+- ⚠️ **인증이 필요한 `NetworkingClient`는 앱 전체에서 하나를 공유**해야 한다. coordinator가 client마다 하나씩 생기므로, client를 화면·모듈마다 새로 만들면 재발급 직렬화가 무의미해진다. (조립부를 만들 때 반드시 지킬 것 — 현재 Demo들은 각자 client를 만든다.)
+- `inFlight` 정리는 재발급 Task 자신의 `defer`가 전담한다 — 그래서 "남의 Task를 지우는" 경우가 없어 세대 가드가 필요 없다. **정리를 대기자 쪽으로 옮기면 즉시 필요해진다.**
 - 도메인을 모른다 — `NetworkingError`를 `RepositoryError`로 바꾸는 건 BaseData(`toRepositoryError()`) 책임. 여기서 하지 말 것.

--- a/Projects/Core/Networking/CLAUDE.md
+++ b/Projects/Core/Networking/CLAUDE.md
@@ -13,9 +13,26 @@ HTTP 클라이언트 + 요청/응답 추상화. Data 레이어가 이걸로 통�
 - `AuthSessionRefreshing.refreshSession() async throws -> Bool` — 401 재인증 훅 (구현체는 AuthData의 `AuthSessionRefresher`).
 - `SessionRefreshCoordinator`(actor) — 401 재인증을 직렬화한다. `NetworkingClient`가 refresher를 받으면 내부에서 생성해 소유한다.
 
+## 서버의 토큰 정책 (2026-08-13 dev 서버 실측)
+
+코드만 봐선 알 수 없고, 재인증 설계 전체가 여기 기댄다.
+
+| 사실 | 확인 방법 |
+|---|---|
+| **refresh token은 1회용** — 이미 쓴 것으로 재발급하면 `401 AUTH-001` | 같은 refresh token으로 `POST /reissue` 두 번 |
+| ⚠️ **무효화가 원자적이지 않다** — 완전 동시(같은 배치)로 5건을 쏘면 **전부 200**이지만, **0.1초만 벌어져도 뒤엣것은 401**이다 | 간격 0.1s / 0.5s / 2s 로 2건씩 |
+| **재발급된 refresh token끼리는 서로 독립적으로 유효**하다 (family 일괄 폐기 없음) | 동시 발급된 5개를 각각 사용 → 전부 200 |
+| 재발급은 **access token 만료 여부와 무관** — refresh만 유효하면 새로 발급 | 만료 전 토큰으로 `POST /reissue` → 200 |
+| **이전 access token은 무효화되지 않는다** — 자체 `exp`까지 그대로 유효 | 재발급 후 옛 access token으로 API 호출 → 200 |
+| 수명: access **30분**, refresh **14일** | JWT `iat`/`exp` |
+
+→ 1·2번째 줄이 중복 재발급이 세션을 끊는 **직접 원인**이다.
+→ 5번째 줄 때문에 아래 2층은 정확성이 아니라 **최적화**(불필요한 왕복·회전 제거)다.
+→ ⚠️ 위는 전부 **dev 서버** 측정값이다. prod 정책이 같은지는 확인되지 않았다.
+
 ## 401 재인증 흐름
 
-서버가 refresh token을 **회전**시키므로 재발급이 동시에 두 번 나가면 나중 것이 폐기된 토큰을 써서 세션 전체가 끊긴다. 이를 세 겹으로 막는다.
+refresh token이 1회용이라, 재발급이 동시에 두 번 나가면 나중 것이 반드시 실패하고 세션이 끊긴다. 이를 세 겹으로 막는다.
 
 1. **coalescing** — 진행 중인 재발급 Task를 공유한다(동시 401 N건 → 재발급 1회).
 2. **토큰 세대 비교** — 요청이 쓴 access token이 저장소의 것과 다르면 이미 남이 갱신한 것이므로 **재발급 없이** 새 토큰으로 재시도한다. coalescing만으로는 "갱신 직후 도착한 401"을 못 잡는다.

--- a/Projects/Core/Networking/CLAUDE.md
+++ b/Projects/Core/Networking/CLAUDE.md
@@ -28,7 +28,22 @@ HTTP 클라이언트 + 요청/응답 추상화. Data 레이어가 이걸로 통�
 
 → 1·2번째 줄이 중복 재발급이 세션을 끊는 **직접 원인**이다.
 → 5번째 줄 때문에 아래 2층은 정확성이 아니라 **최적화**(불필요한 왕복·회전 제거)다.
-→ ⚠️ 위는 전부 **dev 서버** 측정값이다. prod 정책이 같은지는 확인되지 않았다.
+→ 위 수치는 **dev 서버** 실측이고, **prod도 같은 정책**임을 확인받았다(2026-08-13). prod에서 직접 재본 건 아니다.
+
+### 실앱 경로 검증 (#184에서 1회 수행, 재현 레시피)
+
+목이 아니라 **실물 전 계층**(키체인 `DefaultTokenStore` → `AuthSessionRefresher` → `SessionRefreshCoordinator` → 실서버)으로
+"동시 401 4건 → 재발급 1회"를 확인했다. 결과: 재발급 1회, 4건 전부 200, `AUTH-001` 0건, 로그인 라우팅 0회.
+
+의심될 때 **다시 만드는 방법** — 이 시나리오는 유효한 refresh token을 소스에 박아야 해서 레포에 남길 수 없다:
+1. `HomeFeature/Project.swift`의 `demoDependencies`에 `.module(.data(.auth))` 추가
+2. Demo에 시나리오 하나 추가 — `DefaultTokenStore()`에 **만료된 access token + 유효한 refresh token**을 심고,
+   `AuthDataFactory.makeSessionRefresher(client:)`에는 **refresher 없는 client**를 주입(무한 재귀 방지)
+3. `xcrun simctl launch --console-pty`로 콘솔을 잡아 `POST /reissue` 횟수를 센다
+   (`ConsoleLogger`가 `print`라 stdout으로 나온다. macOS엔 `timeout`이 없으니 `perl -e 'alarm N; exec @ARGV'`)
+
+⚠️ **홈이어야 하는 이유**: 앱에서 동시 요청이 나가는 화면이라야 재현된다. 순차 호출 화면에서는 첫 요청이 갱신을
+끝낸 뒤 다음 요청이 새 토큰을 읽어 **401 자체가 한 번만 난다.**
 
 ## 401 재인증 흐름
 

--- a/Projects/Core/Networking/Sources/Auth/SessionRefreshCoordinator.swift
+++ b/Projects/Core/Networking/Sources/Auth/SessionRefreshCoordinator.swift
@@ -70,8 +70,10 @@ private extension SessionRefreshCoordinator {
     /// unstructured라 대기자 하나가 취소돼도 공유 갱신이 죽지 않는다 (의도적 선택).
     func startRefresh() -> Task<SessionRefreshResult, Error> {
         let task = Task { () async throws -> SessionRefreshResult in
-            // `inFlight`는 여기서만 비워지므로 남의 Task를 지울 수 없다.
-            // 정리를 대기자 쪽으로 옮기면 세대 비교 가드가 필요해진다.
+            // ⚠️ `inFlight` 정리는 **이 defer가 전담한다 — 대기자 쪽으로 옮기지 말 것.**
+            // 여기서만 비워지므로 "남의 Task를 지우는" 경우가 원천적으로 없다. 대기자는 여럿이라
+            // 늦게 깬 쪽이 그 사이 시작된 새 Task를 지울 수 있고, 그걸 막으려면 세대 비교 같은
+            // 곁가지 상태가 붙는다. 정리 위치를 지키는 것이 그 복잡도를 통째로 없애는 조건이다.
             defer { self.inFlight = nil }
 
             do {

--- a/Projects/Core/Networking/Sources/Auth/SessionRefreshCoordinator.swift
+++ b/Projects/Core/Networking/Sources/Auth/SessionRefreshCoordinator.swift
@@ -11,7 +11,7 @@ enum SessionRefreshResult {
     case refreshed
     /// 내 토큰만 낡았을 뿐 이미 갱신되어 있었다 → 재발급 없이 재시도 가능
     case alreadyRefreshed
-    /// 세션이 종료됐다 → 재인증 필요
+    /// 서버가 갱신을 거절했다 → 재인증 필요
     case sessionExpired
 }
 
@@ -85,11 +85,17 @@ private extension SessionRefreshCoordinator {
                 }
 
                 return .refreshed
-            } catch let error as NetworkingError where error.indicatesExpiredSession {
-                self.clearTokens()
+            } catch let error as NetworkingError where error.isRefreshRejected {
+                // 서버까지 갔는데 새 토큰을 못 받았다 → 이 토큰으로는 더 진행할 수 없으니 재인증으로 보낸다.
+                // 토큰 삭제는 401(refresh token 자체를 거절)일 때만 한다. 500 같은 일시적 장애에서
+                // 지워버리면 서버가 복구돼도 세션을 되살릴 방법이 없다.
+                if error.indicatesExpiredSession {
+                    self.clearTokens()
+                }
+
                 return .sessionExpired
             }
-            // 그 밖의 에러(통신 실패 등)는 그대로 던진다 → 토큰을 보존한다.
+            // 통신 실패(오프라인·타임아웃)는 세션 상태를 알려주지 않는다 → 그대로 던져 토큰을 보존한다.
         }
 
         inFlight = task
@@ -103,9 +109,24 @@ private extension SessionRefreshCoordinator {
 
 private extension NetworkingError {
 
-    /// 서버가 refresh token 자체를 거절한 경우(401)만 세션 종료로 본다.
-    /// 400·404 같은 요청·배포 문제나 통신 실패는 세션 상태를 알려주지 않으므로,
-    /// 토큰을 지우지 말고 에러를 그대로 전파해야 한다.
+    /// 서버까지 갔다가 **새 토큰을 못 받은 게 확정된** 경우. 통신 실패와 구분하는 기준이다.
+    /// 재시도해도 같은 결과이므로 재인증으로 보낸다. 통신 실패는 세션 상태를 증명하지 않으니
+    /// (다음 시도에 성공할 수 있다) 에러를 그대로 전파해 토큰을 보존한다.
+    ///
+    /// ⚠️ `decoding`이 여기 포함되는 이유 — 응답이 200이어도 스키마가 깨져 파싱에 실패하면
+    /// **저장된 토큰은 낡은 그대로다.** 이걸 흘려보내면 화면은 `.invalidData`만 보고
+    /// 로그인 유도를 못 해, 만료된 토큰으로 같은 실패를 반복하게 된다.
+    var isRefreshRejected: Bool {
+        switch self {
+        case .responseFailure, .decoding:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// 서버가 refresh token 자체를 거절한 경우(401). **토큰을 지우는 건 이때뿐이다.**
+    /// 400·404·5xx는 요청·배포·서버 장애라 토큰이 멀쩡할 수 있으므로 남겨 둔다.
     var indicatesExpiredSession: Bool {
         guard case .responseFailure(let code, _) = self else { return false }
         return code == 401

--- a/Projects/Core/Networking/Sources/Auth/SessionRefreshCoordinator.swift
+++ b/Projects/Core/Networking/Sources/Auth/SessionRefreshCoordinator.swift
@@ -1,0 +1,109 @@
+//
+//  SessionRefreshCoordinator.swift
+//  Networking
+//
+//  Created by YunhakLee on 8/13/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+enum SessionRefreshResult {
+    /// 이 호출이(또는 함께 기다린 호출이) 갱신에 성공했다 → 재시도 가능
+    case refreshed
+    /// 내 토큰만 낡았을 뿐 이미 갱신되어 있었다 → 재발급 없이 재시도 가능
+    case alreadyRefreshed
+    /// 세션이 종료됐다 → 재인증 필요
+    case sessionExpired
+}
+
+/// 401 재인증을 직렬화한다.
+///
+/// 서버가 refresh token을 회전시키므로 재발급이 동시에 두 번 나가면
+/// 나중 것이 폐기된 토큰을 쓰게 되어 세션 전체가 끊긴다. 이를 두 겹으로 막는다.
+/// 1. 진행 중인 재발급이 있으면 새로 시작하지 않고 그 결과를 함께 기다린다.
+/// 2. 요청이 쓴 access token이 이미 낡았다면 재발급 없이 곧바로 재시도시킨다.
+actor SessionRefreshCoordinator {
+    private let refresher: AuthSessionRefreshing
+    private let tokenStore: SessionTokenStore?
+
+    private var inFlight: Task<SessionRefreshResult, Error>?
+
+    init(
+        refresher: AuthSessionRefreshing,
+        tokenStore: SessionTokenStore?
+    ) {
+        self.refresher = refresher
+        self.tokenStore = tokenStore
+    }
+
+    func refresh(usedAccessToken: String?) async throws -> SessionRefreshResult {
+        // ⚠️ 여기부터 `inFlight` 저장까지는 반드시 동기여야 한다.
+        //    중간에 await가 끼면 두 호출이 모두 nil을 보고 각자 재발급을 시작한다.
+        if isAlreadyRefreshed(comparedTo: usedAccessToken) {
+            return .alreadyRefreshed
+        }
+
+        let task = inFlight ?? startRefresh()
+
+        return try await task.value
+    }
+}
+
+private extension SessionRefreshCoordinator {
+
+    /// 내가 보낸 토큰이 지금 저장된 것과 다르다 = 그 사이 누군가 갱신했다.
+    func isAlreadyRefreshed(comparedTo usedAccessToken: String?) -> Bool {
+        guard let usedAccessToken,
+              let current = currentAccessToken(),
+              current.isEmpty == false else {
+            return false
+        }
+
+        return current != usedAccessToken
+    }
+
+    func currentAccessToken() -> String? {
+        guard let tokenStore else { return nil }
+        return try? tokenStore.accessToken()
+    }
+
+    /// `Task {}`는 이 actor의 격리를 물려받으므로 내부에서 상태를 동기로 만질 수 있고,
+    /// unstructured라 대기자 하나가 취소돼도 공유 갱신이 죽지 않는다 (의도적 선택).
+    func startRefresh() -> Task<SessionRefreshResult, Error> {
+        let task = Task { () async throws -> SessionRefreshResult in
+            // `inFlight`는 여기서만 비워지므로 남의 Task를 지울 수 없다.
+            // 정리를 대기자 쪽으로 옮기면 세대 비교 가드가 필요해진다.
+            defer { self.inFlight = nil }
+
+            do {
+                let didRefresh = try await self.refresher.refreshSession()
+
+                guard didRefresh else {
+                    self.clearTokens()
+                    return .sessionExpired
+                }
+
+                return .refreshed
+            } catch let error as NetworkingError where error.indicatesExpiredSession {
+                self.clearTokens()
+                return .sessionExpired
+            }
+            // 그 밖의 에러(통신 실패 등)는 그대로 던진다 → 토큰을 보존한다.
+        }
+
+        inFlight = task
+        return task
+    }
+
+    func clearTokens() {
+        try? tokenStore?.clearTokens()
+    }
+}
+
+private extension NetworkingError {
+
+    /// 4xx = 서버가 이 세션을 거절 / 그 외 = 일시적 실패
+    var indicatesExpiredSession: Bool {
+        guard case .responseFailure(let code, _) = self else { return false }
+        return (400..<500).contains(code)
+    }
+}

--- a/Projects/Core/Networking/Sources/Auth/SessionRefreshCoordinator.swift
+++ b/Projects/Core/Networking/Sources/Auth/SessionRefreshCoordinator.swift
@@ -101,9 +101,11 @@ private extension SessionRefreshCoordinator {
 
 private extension NetworkingError {
 
-    /// 4xx = 서버가 이 세션을 거절 / 그 외 = 일시적 실패
+    /// 서버가 refresh token 자체를 거절한 경우(401)만 세션 종료로 본다.
+    /// 400·404 같은 요청·배포 문제나 통신 실패는 세션 상태를 알려주지 않으므로,
+    /// 토큰을 지우지 말고 에러를 그대로 전파해야 한다.
     var indicatesExpiredSession: Bool {
         guard case .responseFailure(let code, _) = self else { return false }
-        return (400..<500).contains(code)
+        return code == 401
     }
 }

--- a/Projects/Core/Networking/Sources/Client/NetworkingClient.swift
+++ b/Projects/Core/Networking/Sources/Client/NetworkingClient.swift
@@ -8,11 +8,14 @@
 import Foundation
 
 public final class NetworkingClient: NetworkingRequestable {
+    /// 한 요청이 시도할 수 있는 재인증 횟수 상한. 무한 루프를 막는다.
+    private static let maxAuthRetries = 2
+
     private let urlSession: URLSession
     private let logger: NetworkLogging?
     private let tokenStore: SessionTokenStore?
-    private let authSessionRefresher: AuthSessionRefreshing?
-    
+    private let refreshCoordinator: SessionRefreshCoordinator?
+
     public init(
         urlSession: URLSession = .shared,
         logger: NetworkLogging? = nil,
@@ -22,23 +25,34 @@ public final class NetworkingClient: NetworkingRequestable {
         self.urlSession = urlSession
         self.logger = logger
         self.tokenStore = tokenStore
-        self.authSessionRefresher = authSessionRefresher
+        self.refreshCoordinator = authSessionRefresher.map {
+            SessionRefreshCoordinator(refresher: $0, tokenStore: tokenStore)
+        }
     }
-    
+
     public func request(_ endpoint: Endpoint) async throws -> Data {
+        try await request(endpoint, remainingAuthRetries: Self.maxAuthRetries)
+    }
+
+    private func request(
+        _ endpoint: Endpoint,
+        remainingAuthRetries: Int
+    ) async throws -> Data {
         let authorizationContext = makeAuthorizationContext(for: endpoint)
-        
+
         do {
             return try await executeRequest(endpoint, authorizationContext: authorizationContext)
         } catch let error as NetworkingError {
             switch error {
             case .responseFailure(let code, _) where code == 401:
-                guard authorizationContext.canRefreshSession else {
+                guard authorizationContext.canRefreshSession,
+                      remainingAuthRetries > 0 else {
                     throw error
                 }
                 return try await retryAfterRefreshingSession(
                     for: endpoint,
-                    authorizationContext: authorizationContext
+                    authorizationContext: authorizationContext,
+                    remainingAuthRetries: remainingAuthRetries - 1
                 )
             case .responseFailure(let code, let body) where code == 404 && body?.code == "USER-006":
                 try? tokenStore?.clearTokens()
@@ -48,7 +62,7 @@ public final class NetworkingClient: NetworkingRequestable {
             }
         }
     }
-    
+
     private func executeRequest(
         _ endpoint: Endpoint,
         authorizationContext: AuthorizationContext
@@ -60,7 +74,7 @@ public final class NetworkingClient: NetworkingRequestable {
         logger?.logRequest(request)
 
         let (data, response): (Data, URLResponse)
-        
+
         do {
             (data, response) = try await urlSession.data(for: request)
         } catch {
@@ -81,53 +95,64 @@ public final class NetworkingClient: NetworkingRequestable {
 
 extension NetworkingClient {
     private struct AuthorizationContext {
-        let canUseToken: Bool
+        /// 이번 시도에 실제로 헤더에 담은 토큰. nil이면 미첨부.
+        let accessToken: String?
         let canRefreshSession: Bool
     }
-    
+
     private func makeAuthorizationContext(for endpoint: Endpoint) -> AuthorizationContext {
         switch endpoint.authorization {
         case .requireToken:
-            return AuthorizationContext(canUseToken: true, canRefreshSession: true)
-        case .withoutToken:
-            return AuthorizationContext(canUseToken: false, canRefreshSession: false)
-        case .usesTokenIfAvailable:
-            let hasAccessToken = currentAccessToken()?.isEmpty == false
             return AuthorizationContext(
-                canUseToken: hasAccessToken,
+                accessToken: currentAccessToken(),
+                canRefreshSession: true
+            )
+        case .withoutToken:
+            return AuthorizationContext(
+                accessToken: nil,
+                canRefreshSession: false
+            )
+        case .usesTokenIfAvailable:
+            let accessToken = currentAccessToken()
+            let hasAccessToken = accessToken?.isEmpty == false
+            return AuthorizationContext(
+                accessToken: hasAccessToken ? accessToken : nil,
                 canRefreshSession: hasAccessToken
             )
         }
     }
-    
+
+    /// 세션 종료 판정과 토큰 정리는 `SessionRefreshCoordinator`가 전담한다.
+    /// 통신 실패는 세션 종료가 아니므로 에러를 그대로 전파해 토큰을 보존한다.
     private func retryAfterRefreshingSession(
         for endpoint: Endpoint,
-        authorizationContext: AuthorizationContext
+        authorizationContext: AuthorizationContext,
+        remainingAuthRetries: Int
     ) async throws -> Data {
-        let refreshSuccess: Bool
-        do {
-            refreshSuccess = try await authSessionRefresher?.refreshSession() ?? false
-        } catch {
-            try? tokenStore?.clearTokens()
+        guard let refreshCoordinator else {
             throw NetworkingError.requiresReauthentication
         }
 
-        guard refreshSuccess else {
-            try? tokenStore?.clearTokens()
+        let result = try await refreshCoordinator.refresh(
+            usedAccessToken: authorizationContext.accessToken
+        )
+
+        switch result {
+        case .refreshed, .alreadyRefreshed:
+            // 재귀 진입점에서 갱신된 토큰을 다시 읽는다. 카운터가 무한 루프를 막는다.
+            return try await request(endpoint, remainingAuthRetries: remainingAuthRetries)
+        case .sessionExpired:
             throw NetworkingError.requiresReauthentication
         }
-       
-        return try await executeRequest(endpoint, authorizationContext: authorizationContext)
     }
-    
+
     private func authorizedRequest(
         for endpoint: Endpoint,
         authorizationContext: AuthorizationContext
     ) throws -> URLRequest {
         var request = try endpoint.makeURLRequest()
 
-        guard authorizationContext.canUseToken,
-              let accessToken = currentAccessToken(),
+        guard let accessToken = authorizationContext.accessToken,
               accessToken.isEmpty == false else {
             return request
         }
@@ -135,19 +160,19 @@ extension NetworkingClient {
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         return request
     }
-    
+
     private func currentAccessToken() -> String? {
         guard let tokenStore else { return nil }
         return try? tokenStore.accessToken()
     }
-    
+
     private func validateResponse(data: Data, response: URLResponse) async throws {
         guard let http = response as? HTTPURLResponse else {
             throw NetworkingError.invalidURL
         }
-        
+
         let errorResponse = try? JSONDecoder().decode(ErrorResponse.self, from: data)
-        
+
         switch http.statusCode {
         case 200..<300:
             return

--- a/Projects/Core/Networking/Testing/MockAuthSessionRefresher.swift
+++ b/Projects/Core/Networking/Testing/MockAuthSessionRefresher.swift
@@ -1,26 +1,46 @@
+import Foundation
 @testable import Networking
 
-final class MockAuthSessionRefresher: AuthSessionRefreshing {
+/// 동시 요청 테스트에서 여러 스레드가 함께 호출하므로 카운터를 락으로 보호한다.
+final class MockAuthSessionRefresher: AuthSessionRefreshing, @unchecked Sendable {
     enum Behavior {
         case success(Bool)
         case failure(Error)
     }
 
-    private let behavior: Behavior
-    private(set) var refreshCallCount = 0
+    private let lock = NSLock()
+    private var callCount = 0
+    private let onRefresh: () async throws -> Bool
+
+    var refreshCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return callCount
+    }
 
     init(behavior: Behavior) {
-        self.behavior = behavior
+        switch behavior {
+        case .success(let result):
+            self.onRefresh = { result }
+        case .failure(let error):
+            self.onRefresh = { throw error }
+        }
+    }
+
+    /// 지연·토큰 회전 등 갱신 도중의 동작을 직접 기술할 때 사용한다.
+    init(onRefresh: @escaping () async throws -> Bool) {
+        self.onRefresh = onRefresh
     }
 
     func refreshSession() async throws -> Bool {
-        refreshCallCount += 1
+        recordCall()
+        return try await onRefresh()
+    }
 
-        switch behavior {
-        case .success(let result):
-            return result
-        case .failure(let error):
-            throw error
-        }
+    /// `NSLock`은 async 컨텍스트에서 직접 쓸 수 없어 동기 메서드로 감싼다.
+    private func recordCall() {
+        lock.lock()
+        defer { lock.unlock() }
+        callCount += 1
     }
 }

--- a/Projects/Core/Networking/Testing/MockTokenStore.swift
+++ b/Projects/Core/Networking/Testing/MockTokenStore.swift
@@ -1,13 +1,39 @@
+import Foundation
 @testable import Networking
 
-final class MockTokenStore: SessionTokenStore {
-    private let storedAccessToken: String?
-    private(set) var clearTokensCallCount = 0
+/// 동시 요청 테스트에서 여러 스레드가 함께 접근하므로 락으로 보호한다.
+final class MockTokenStore: SessionTokenStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedAccessToken: String?
+    private var clearCount = 0
+
+    var clearTokensCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return clearCount
+    }
 
     init(accessToken: String?) {
         self.storedAccessToken = accessToken
     }
 
-    func accessToken() throws -> String? { storedAccessToken }
-    func clearTokens() throws { clearTokensCallCount += 1 }
+    func accessToken() throws -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedAccessToken
+    }
+
+    func clearTokens() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        clearCount += 1
+        storedAccessToken = nil
+    }
+
+    /// 서버의 토큰 회전을 흉내낸다.
+    func update(accessToken: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        storedAccessToken = accessToken
+    }
 }

--- a/Projects/Core/Networking/Tests/NetworkingClientTests.swift
+++ b/Projects/Core/Networking/Tests/NetworkingClientTests.swift
@@ -504,6 +504,74 @@ struct NetworkingClientTests {
         #expect(tokenStore.clearTokensCallCount == 0)
     }
 
+    @Test("refresh가 401로 거절되면 세션을 종료하고 토큰을 지운다")
+    func clearsTokensWhenRefreshIsRejectedWithUnauthorized() async {
+        MockURLProtocol.requestHandler = nil
+        let refresher = MockAuthSessionRefresher(
+            behavior: .failure(NetworkingError.responseFailure(
+                code: 401,
+                body: ErrorResponse(code: "AUTH-001", message: "유효하지 않은 토큰입니다.")
+            ))
+        )
+        let tokenStore = MockTokenStore(accessToken: "access-token")
+        let client = makeClient(
+            tokenStore: tokenStore,
+            authSessionRefresher: refresher
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            try makeResponse(for: request, statusCode: 401)
+        }
+
+        do {
+            _ = try await client.request(MockEndpoint(authorization: .requireToken))
+            Issue.record("requiresReauthentication expected")
+        } catch let error as NetworkingError {
+            guard case .requiresReauthentication = error else {
+                Issue.record("unexpected error: \(error)")
+                return
+            }
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        #expect(refresher.refreshCallCount == 1)
+        #expect(tokenStore.clearTokensCallCount == 1)
+    }
+
+    @Test("refresh가 404로 실패하면 세션 종료로 보지 않고 토큰을 보존한다")
+    func keepsTokensWhenRefreshFailsWithNonAuthStatus() async {
+        MockURLProtocol.requestHandler = nil
+        let refresher = MockAuthSessionRefresher(
+            behavior: .failure(NetworkingError.responseFailure(code: 404, body: nil))
+        )
+        let tokenStore = MockTokenStore(accessToken: "access-token")
+        let client = makeClient(
+            tokenStore: tokenStore,
+            authSessionRefresher: refresher
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            try makeResponse(for: request, statusCode: 401)
+        }
+
+        do {
+            _ = try await client.request(MockEndpoint(authorization: .requireToken))
+            Issue.record("responseFailure expected")
+        } catch let error as NetworkingError {
+            guard case .responseFailure(let code, _) = error else {
+                Issue.record("unexpected error: \(error)")
+                return
+            }
+
+            #expect(code == 404)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        #expect(tokenStore.clearTokensCallCount == 0)
+    }
+
     @Test("동시에 401을 받아도 토큰 재발급은 한 번만 실행된다")
     func refreshesOnlyOnceForConcurrentUnauthorizedResponses() async throws {
         MockURLProtocol.requestHandler = nil

--- a/Projects/Core/Networking/Tests/NetworkingClientTests.swift
+++ b/Projects/Core/Networking/Tests/NetworkingClientTests.swift
@@ -472,10 +472,12 @@ struct NetworkingClientTests {
         #expect(tokenStore.clearTokensCallCount == 1)
     }
 
-    @Test("refresh 중 에러 발생 시 토큰을 삭제하고 재인증 에러를 던진다")
-    func clearsTokensWhenRefreshThrows() async {
+    @Test("통신 실패로 refresh가 던지면 토큰을 보존하고 원래 에러를 전파한다")
+    func keepsTokensWhenRefreshFailsWithTransportError() async {
         MockURLProtocol.requestHandler = nil
-        let refresher = MockAuthSessionRefresher(behavior: .failure(URLError(.cannotConnectToHost)))
+        let refresher = MockAuthSessionRefresher(
+            behavior: .failure(NetworkingError.unknown(URLError(.cannotConnectToHost)))
+        )
         let tokenStore = MockTokenStore(accessToken: "access-token")
         let client = makeClient(
             tokenStore: tokenStore,
@@ -488,9 +490,9 @@ struct NetworkingClientTests {
 
         do {
             _ = try await client.request(MockEndpoint(authorization: .requireToken))
-            Issue.record("requiresReauthentication expected")
+            Issue.record("unknown error expected")
         } catch let error as NetworkingError {
-            guard case .requiresReauthentication = error else {
+            guard case .unknown = error else {
                 Issue.record("unexpected error: \(error)")
                 return
             }
@@ -499,7 +501,101 @@ struct NetworkingClientTests {
         }
 
         #expect(refresher.refreshCallCount == 1)
-        #expect(tokenStore.clearTokensCallCount == 1)
+        #expect(tokenStore.clearTokensCallCount == 0)
+    }
+
+    @Test("동시에 401을 받아도 토큰 재발급은 한 번만 실행된다")
+    func refreshesOnlyOnceForConcurrentUnauthorizedResponses() async throws {
+        MockURLProtocol.requestHandler = nil
+        let tokenStore = MockTokenStore(accessToken: "old-token")
+        let refresher = MockAuthSessionRefresher {
+            // 재발급이 겹칠 시간을 만든다. 없으면 순차 실행되어 버그가 있어도 통과한다.
+            try await Task.sleep(nanoseconds: 50_000_000)
+            tokenStore.update(accessToken: "new-token")
+            return true
+        }
+        let client = makeClient(
+            tokenStore: tokenStore,
+            authSessionRefresher: refresher
+        )
+
+        // 순번이 아니라 "어떤 토큰으로 왔는가"로 판정한다. 동시 요청에선 순번이 비결정적이다.
+        MockURLProtocol.requestHandler = { request in
+            let isRenewed = request.value(forHTTPHeaderField: "Authorization") == "Bearer new-token"
+            return try makeResponse(for: request, statusCode: isRenewed ? 200 : 401)
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask {
+                    _ = try await client.request(MockEndpoint(authorization: .requireToken))
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        #expect(refresher.refreshCallCount == 1)
+        #expect(tokenStore.clearTokensCallCount == 0)
+    }
+
+    @Test("이미 갱신된 뒤 도착한 401은 재발급 없이 새 토큰으로 재시도한다")
+    func retriesWithoutRefreshingWhenTokenWasAlreadyRenewed() async throws {
+        MockURLProtocol.requestHandler = nil
+        let tokenStore = MockTokenStore(accessToken: "old-token")
+        let refresher = MockAuthSessionRefresher(behavior: .success(true))
+        let client = makeClient(
+            tokenStore: tokenStore,
+            authSessionRefresher: refresher
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            guard request.value(forHTTPHeaderField: "Authorization") == "Bearer old-token" else {
+                return try makeResponse(for: request, statusCode: 200)
+            }
+            // 내 요청이 나간 뒤 다른 요청이 갱신을 끝낸 상황
+            tokenStore.update(accessToken: "new-token")
+            return try makeResponse(for: request, statusCode: 401)
+        }
+
+        _ = try await client.request(MockEndpoint(authorization: .requireToken))
+
+        #expect(refresher.refreshCallCount == 0)
+        #expect(tokenStore.clearTokensCallCount == 0)
+    }
+
+    @Test("재발급 후에도 401이면 두 번까지만 재발급하고 401을 유지한다")
+    func stopsRefreshingAfterReachingMaxAuthRetries() async {
+        MockURLProtocol.requestHandler = nil
+        let tokenStore = MockTokenStore(accessToken: "access-token")
+        let issuedTokenCount = LockedCounter()
+        let refresher = MockAuthSessionRefresher {
+            tokenStore.update(accessToken: "token-\(issuedTokenCount.increment())")
+            return true
+        }
+        let client = makeClient(
+            tokenStore: tokenStore,
+            authSessionRefresher: refresher
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            try makeResponse(for: request, statusCode: 401)
+        }
+
+        do {
+            _ = try await client.request(MockEndpoint(authorization: .requireToken))
+            Issue.record("responseFailure expected")
+        } catch let error as NetworkingError {
+            guard case .responseFailure(let code, _) = error else {
+                Issue.record("unexpected error: \(error)")
+                return
+            }
+
+            #expect(code == 401)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        #expect(refresher.refreshCallCount == 2)
     }
 }
 

--- a/Projects/Core/Networking/Tests/NetworkingClientTests.swift
+++ b/Projects/Core/Networking/Tests/NetworkingClientTests.swift
@@ -539,8 +539,11 @@ struct NetworkingClientTests {
         #expect(tokenStore.clearTokensCallCount == 1)
     }
 
-    @Test("refresh가 404로 실패하면 세션 종료로 보지 않고 토큰을 보존한다")
-    func keepsTokensWhenRefreshFailsWithNonAuthStatus() async {
+    /// 404·5xx는 "이 토큰으로는 갱신이 안 된다"까지만 알려준다 → 재인증으로 보내되,
+    /// 토큰까지 지우면 서버가 복구돼도 세션을 되살릴 수 없으므로 남긴다.
+    /// 재발급 실패를 원 요청의 404로 흘려보내면 화면이 "없는 리소스"로 오해한다.
+    @Test("refresh가 404로 실패하면 토큰은 보존한 채 재인증을 요구한다")
+    func requiresReauthenticationButKeepsTokensWhenRefreshFailsWithNonAuthStatus() async {
         MockURLProtocol.requestHandler = nil
         let refresher = MockAuthSessionRefresher(
             behavior: .failure(NetworkingError.responseFailure(code: 404, body: nil))
@@ -557,14 +560,43 @@ struct NetworkingClientTests {
 
         do {
             _ = try await client.request(MockEndpoint(authorization: .requireToken))
-            Issue.record("responseFailure expected")
+            Issue.record("requiresReauthentication expected")
         } catch let error as NetworkingError {
-            guard case .responseFailure(let code, _) = error else {
+            guard case .requiresReauthentication = error else {
                 Issue.record("unexpected error: \(error)")
                 return
             }
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
 
-            #expect(code == 404)
+        #expect(tokenStore.clearTokensCallCount == 0)
+    }
+
+    /// 200을 받아도 스키마가 깨져 파싱에 실패하면 **저장된 토큰은 낡은 그대로**다.
+    /// 이걸 데이터 오류로 흘려보내면 화면이 로그인 유도를 못 해 같은 실패만 반복한다.
+    @Test("refresh 응답 파싱에 실패하면 토큰은 보존한 채 재인증을 요구한다")
+    func requiresReauthenticationButKeepsTokensWhenRefreshResponseCannotBeDecoded() async {
+        MockURLProtocol.requestHandler = nil
+        let refresher = MockAuthSessionRefresher(behavior: .failure(NetworkingError.decoding))
+        let tokenStore = MockTokenStore(accessToken: "access-token")
+        let client = makeClient(
+            tokenStore: tokenStore,
+            authSessionRefresher: refresher
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            try makeResponse(for: request, statusCode: 401)
+        }
+
+        do {
+            _ = try await client.request(MockEndpoint(authorization: .requireToken))
+            Issue.record("requiresReauthentication expected")
+        } catch let error as NetworkingError {
+            guard case .requiresReauthentication = error else {
+                Issue.record("unexpected error: \(error)")
+                return
+            }
         } catch {
             Issue.record("unexpected error: \(error)")
         }
@@ -587,9 +619,16 @@ struct NetworkingClientTests {
             authSessionRefresher: refresher
         )
 
+        let unauthorizedCount = LockedCounter()
+
         // 순번이 아니라 "어떤 토큰으로 왔는가"로 판정한다. 동시 요청에선 순번이 비결정적이다.
         MockURLProtocol.requestHandler = { request in
             let isRenewed = request.value(forHTTPHeaderField: "Authorization") == "Bearer new-token"
+
+            if isRenewed == false {
+                _ = unauthorizedCount.increment()
+            }
+
             return try makeResponse(for: request, statusCode: isRenewed ? 200 : 401)
         }
 
@@ -602,6 +641,16 @@ struct NetworkingClientTests {
             try await group.waitForAll()
         }
 
+        // ⚠️ **겹침이 실제로 일어났는지**를 함께 못 박는다 — 이 단언이 없으면 요청들이 순차로 밀려
+        // 갱신 뒤에 도착해도(=겹치지 않아도) 재발급 1회라 통과해버린다(가짜 green).
+        // `== 5`로 조이지 않는 이유는 그쪽이 스케줄링에 기대는 flaky 조건이 되기 때문 —
+        // 부하로 한 요청만 늦게 출발해도 구현이 멀쩡한데 빨간불이 뜬다.
+        #expect(unauthorizedCount.value >= 2)
+
+        // 여기서 못 박는 건 **결과**다 — "동시 401 N건이 재발급 1회로 합쳐진다". 그걸 막은 게
+        // coalescing인지 토큰 세대 비교인지는 구분하지 않는다(둘 다 있어야 하는 방어이고,
+        // 세대 비교는 바로 아래 테스트가 따로 검증한다). 둘을 완전히 분리하려면 재발급이 토큰을
+        // 갱신하지 않는 더블이 필요한데, 그러면 재시도 상한과 얽혀 다시 타이밍에 기대게 된다.
         #expect(refresher.refreshCallCount == 1)
         #expect(tokenStore.clearTokensCallCount == 0)
     }

--- a/Projects/Domain/RecommendationDomain/CLAUDE.md
+++ b/Projects/Domain/RecommendationDomain/CLAUDE.md
@@ -7,8 +7,8 @@
 
 ## 핵심 시나리오
 
-- **`LoadHomeDataUseCase`가 핵심**: Repository의 3개 호출(today/trending/preference)을 **순차 실행**하고
-  캐시된 닉네임을 얹어 `HomeData` 하나로 합친다. 홈 진입 시 이걸 부른다.
+- **`LoadHomeDataUseCase`가 핵심**: Repository의 3개 호출(today/trending/preference)을 **`async let`으로 동시에**
+  부르고, 캐시된 닉네임을 얹어 `HomeData` 하나로 합친다. 홈 진입 시 이걸 부른다.
 - 소소픽(`LoadSosoPickUseCase`)은 별도.
 - 일부는 상태 래퍼 반환: `InterestFeedState`, `PreferenceGenreNovelState` (미설정·빈 상태 등 표현).
 
@@ -16,9 +16,30 @@
 
 - ⚠️ **관심글(`fetchInterestFeeds`)은 `LoadHomeDataUseCase`가 일부러 호출하지 않는다**(#179). 홈 디자인에
   관심글 섹션이 없어서다 — 구 WSSiOS 홈에서도 이미 미사용이었다. Entity·Repository·DTO는 남겨뒀으니
-  섹션이 부활하면 되살려 쓰면 된다. **"4개 다 부르는 게 자연스럽다"고 되돌리지 말 것**: `/feeds/interest`는
-  `requireToken`이라 순차 호출 특성상 이 하나 때문에 홈 전체가 함께 죽는다.
-- `LoadHomeDataUseCase`의 3개 호출은 순차(`await` 연속) — 하나 실패 시 전체 실패. 병렬화/부분 실패 허용이 필요하면 여기 수정.
+  섹션이 부활하면 되살려 쓰면 된다. **"4개 다 부르는 게 자연스럽다"고 되돌리지 말 것**: 하나라도 실패하면
+  홈 전체가 실패하므로, 화면에 안 쓰는 호출을 끼우면 홈이 함께 죽을 확률만 올라간다.
+- ⚠️ **3개 호출을 순차(`try await` 연속)로 펴지 말 것 — 한 번 그렇게 퇴행한 적이 있다.**
+  원래 `async let`이었는데 `c1e19ed0`(*[Chore] #51 - throws 타입 통일*)에서 순차로 바뀌었다. 커밋 의도는
+  타입 통일이었고 병렬성 얘기는 메시지에 없다 — 아래 컴파일 함정을 피하려다 딸려온 부수 피해다.
+  (실측 차이: 순차 0.34~0.52s ↔ 병렬 0.16~0.19s. 홈은 탭 복귀마다 갱신하니 매번 낸다.)
+- ⚠️ **`async let`은 타입 지정 throw(`throws(RepositoryError)`)를 `any Error`로 지운다.**
+  그래서 `throws(RepositoryError)` 함수 안에서 `try await`로 수확하면 *"thrown expression type 'any Error'
+  cannot be converted"* 로 컴파일이 깨진다. **병렬성을 포기하지 말고** `do/catch`로 감싸
+  `catch let error as RepositoryError { throw error } catch { throw .unknown }` 로 되돌리면 된다.
+  (감싸는 함수가 비-throw면 이 문제가 안 보인다 — `MypageViewModel`이 그래서 멀쩡하다.)
+  - ⚠️ **`withThrowingTaskGroup`으로 갈아타도 이 `do/catch`는 사라지지 않는다** — 그쪽도 에러 타입이
+    `any Error`다. 게다가 여기는 반환 타입이 셋 다 달라 래퍼 enum + switch 되풀기가 붙어 **더 길어진다**
+    (TaskGroup은 같은 타입 N개를 동적으로 돌릴 때 쓰는 도구다). "에러 처리가 지저분하니 TaskGroup"은
+    막다른 길이니 다시 시도하지 말 것. 줄이려면 `try await (a, b, c)` 튜플 수확으로 `do` 블록을 한 줄로 만든다.
+  - ⚠️ **`Result { try await ... }.mapError { }` 로 감싸는 것도 불가능하다** — `async let` 바인딩은
+    escaping/non-escaping 무관하게 **어떤 클로저에도 캡처될 수 없다**(*capturing 'async let' variables is
+    not supported*, SE-0317). 아이디어 자체는 맞다(`Result.get()`이 `throws(Failure)`라 타입이 딱 맞는다).
+    막힌 건 클로저 캡처 규칙이다. 굳이 하려면 `async let`을 `Task {}` 핸들로 바꿔야 하는데, 그러면
+    구조적 동시성을 잃어 **형제 태스크 자동 취소가 사라진다** — 얻는 것보다 잃는 게 크다.
+- **`issuesThreeCallsConcurrently` 테스트가 이 UseCase의 퇴행 방지선이다** — 지우거나 약화시키지 말 것.
+  위 퇴행이 났을 때 아무 테스트도 안 깨져서 아무도 몰랐다. **벽시계 시간이 아니라 "같은 시각에 겹친 호출 수"**
+  (병렬 3 / 순차 1)를 재는 이유는 머신 부하에 흔들리지 않게 하기 위해서다 — 시간 측정으로 "단순화"하면
+  CI에서 깜빡이다가 결국 삭제된다.
 - **닉네임은 네트워크가 아니라 로컬 캐시**다 — `fetchCachedNickname()`만 `async`·`throws`가 아닌 이유
   (Data가 `AppStorage`의 `.nickname`을 읽는다). 값이 없으면 nil이고, 그 표기는 화면이 정한다.
 - ⚠️ **`TodayDiscovery`·`TrendingFeed`에 UI 카피를 되돌리지 말 것**(#179에서 제거). `title`("작품 소개"/

--- a/Projects/Domain/RecommendationDomain/Sources/Usecase/LoadHomeDataUseCase.swift
+++ b/Projects/Domain/RecommendationDomain/Sources/Usecase/LoadHomeDataUseCase.swift
@@ -22,18 +22,31 @@ public final class DefaultLoadHomeDataUseCase: LoadHomeDataUseCase {
         self.recommendationRepository = repository
     }
 
-    /// ⚠️ 관심글(`fetchInterestFeeds`)은 홈 화면에 섹션이 없어 **일부러 호출하지 않는다.**
-    /// requireToken 호출을 하나 줄이는 효과도 있다(아래 순차 실행 특성 때문에 홈 전체가 함께 죽는 걸 막는다).
+    /// 세 호출은 서로 독립이라 **`async let`으로 동시에** 부른다. 순차로 펴면 왕복 지연이 그대로 쌓이는데,
+    /// 홈은 탭 복귀마다 갱신하는 화면이라 그 비용을 매번 낸다(실측: 순차 0.34~0.52s ↔ 병렬 0.16~0.19s).
+    ///
     public func execute() async throws(RepositoryError) -> HomeData {
-        let todayDiscoveries = try await recommendationRepository.fetchTodayDiscoveries()
-        let trendingFeeds = try await recommendationRepository.fetchTrendingFeeds()
-        let preferenceGenreNovelState = try await recommendationRepository.fetchPreferenceGenreNovels()
+        async let todayDiscoveries = recommendationRepository.fetchTodayDiscoveries()
+        async let trendingFeeds = recommendationRepository.fetchTrendingFeeds()
+        async let preferenceGenreNovelState = recommendationRepository.fetchPreferenceGenreNovels()
+
+        // ⚠️ `async let`은 타입 지정 throw를 `any Error`로 지운다 → 여기서 되돌려야 컴파일된다
+        // (`withThrowingTaskGroup`도 마찬가지라 바꿔도 이 블록은 사라지지 않는다).
+        // Repository는 `throws(RepositoryError)`라 두 번째 분기는 실제로는 도달하지 않는다.
+        let loaded: ([TodayDiscovery], [TrendingFeed], PreferenceGenreNovelState)
+        do {
+            loaded = try await (todayDiscoveries, trendingFeeds, preferenceGenreNovelState)
+        } catch let error as RepositoryError {
+            throw error
+        } catch {
+            throw RepositoryError.unknown
+        }
 
         return HomeData(
             nickname: recommendationRepository.fetchCachedNickname(),
-            todayDiscoveries: todayDiscoveries,
-            trendingFeeds: trendingFeeds,
-            preferenceGenreNovelState: preferenceGenreNovelState
+            todayDiscoveries: loaded.0,
+            trendingFeeds: loaded.1,
+            preferenceGenreNovelState: loaded.2
         )
     }
 }

--- a/Projects/Domain/RecommendationDomain/Testing/MockRecommendationRepository.swift
+++ b/Projects/Domain/RecommendationDomain/Testing/MockRecommendationRepository.swift
@@ -11,67 +11,115 @@ import Foundation
 import RecommendationDomain
 import BaseDomain
 
-public final class MockRecommendationRepository: RecommendationRepository {
+/// `LoadHomeDataUseCase`가 세 호출을 `async let`으로 **동시에** 부르므로 카운터가 동시에 증가한다.
+/// 락 없이 두면 호출 횟수 자체를 믿을 수 없어 테스트가 조용히 흔들린다.
+public final class MockRecommendationRepository: RecommendationRepository, @unchecked Sendable {
 
-    public var fetchTodayDiscoveriesCallCount = 0
-    public var fetchTrendingFeedsCallCount = 0
-    public var fetchInterestFeedsCallCount = 0
-    public var fetchRecommendedNovelsCallCount = 0
-    public var fetchSosoPickCallCount = 0
-    public var fetchCachedNicknameCallCount = 0
+    private struct State {
+        var fetchTodayDiscoveriesCallCount = 0
+        var fetchTrendingFeedsCallCount = 0
+        var fetchInterestFeedsCallCount = 0
+        var fetchRecommendedNovelsCallCount = 0
+        var fetchSosoPickCallCount = 0
+        var fetchCachedNicknameCallCount = 0
 
-    public var cachedNickname: String?
+        var cachedNickname: String?
 
-    public var fetchTodayDiscoveriesResult: Result<[TodayDiscovery], RepositoryError> = .success([])
-    public var fetchTrendingFeedsResult: Result<[TrendingFeed], RepositoryError> = .success([])
-    public var fetchInterestFeedsResult: Result<InterestFeedState, RepositoryError> = .success(.noInterestSettings)
-    public var fetchRecommendedNovelsResult: Result<PreferenceGenreNovelState, RepositoryError> = .success(.noGenreSettings)
-    public var fetchSosoPickResult: Result<[SosoPick], RepositoryError> = .success([])
+        var fetchTodayDiscoveriesResult: Result<[TodayDiscovery], RepositoryError> = .success([])
+        var fetchTrendingFeedsResult: Result<[TrendingFeed], RepositoryError> = .success([])
+        var fetchInterestFeedsResult: Result<InterestFeedState, RepositoryError> = .success(.noInterestSettings)
+        var fetchRecommendedNovelsResult: Result<PreferenceGenreNovelState, RepositoryError> = .success(.noGenreSettings)
+        var fetchSosoPickResult: Result<[SosoPick], RepositoryError> = .success([])
+    }
+
+    private let lock = NSLock()
+    private var state = State()
 
     public init() {}
 
+    // MARK: - 호출 횟수
+
+    public var fetchTodayDiscoveriesCallCount: Int { withLock { state.fetchTodayDiscoveriesCallCount } }
+    public var fetchTrendingFeedsCallCount: Int { withLock { state.fetchTrendingFeedsCallCount } }
+    public var fetchInterestFeedsCallCount: Int { withLock { state.fetchInterestFeedsCallCount } }
+    public var fetchRecommendedNovelsCallCount: Int { withLock { state.fetchRecommendedNovelsCallCount } }
+    public var fetchSosoPickCallCount: Int { withLock { state.fetchSosoPickCallCount } }
+    public var fetchCachedNicknameCallCount: Int { withLock { state.fetchCachedNicknameCallCount } }
+
+    // MARK: - 스텁
+
+    public var cachedNickname: String? {
+        get { withLock { state.cachedNickname } }
+        set { withLock { state.cachedNickname = newValue } }
+    }
+
+    public var fetchTodayDiscoveriesResult: Result<[TodayDiscovery], RepositoryError> {
+        get { withLock { state.fetchTodayDiscoveriesResult } }
+        set { withLock { state.fetchTodayDiscoveriesResult = newValue } }
+    }
+
+    public var fetchTrendingFeedsResult: Result<[TrendingFeed], RepositoryError> {
+        get { withLock { state.fetchTrendingFeedsResult } }
+        set { withLock { state.fetchTrendingFeedsResult = newValue } }
+    }
+
+    public var fetchInterestFeedsResult: Result<InterestFeedState, RepositoryError> {
+        get { withLock { state.fetchInterestFeedsResult } }
+        set { withLock { state.fetchInterestFeedsResult = newValue } }
+    }
+
+    public var fetchRecommendedNovelsResult: Result<PreferenceGenreNovelState, RepositoryError> {
+        get { withLock { state.fetchRecommendedNovelsResult } }
+        set { withLock { state.fetchRecommendedNovelsResult = newValue } }
+    }
+
+    public var fetchSosoPickResult: Result<[SosoPick], RepositoryError> {
+        get { withLock { state.fetchSosoPickResult } }
+        set { withLock { state.fetchSosoPickResult = newValue } }
+    }
+
+    // MARK: - RecommendationRepository
+
     public func fetchTodayDiscoveries() async throws(RepositoryError) -> [TodayDiscovery] {
-        fetchTodayDiscoveriesCallCount += 1
-        switch fetchTodayDiscoveriesResult {
-        case .success(let value): return value
-        case .failure(let error): throw error
-        }
+        try resolve(withLock { state.fetchTodayDiscoveriesCallCount += 1; return state.fetchTodayDiscoveriesResult })
     }
 
     public func fetchTrendingFeeds() async throws(RepositoryError) -> [TrendingFeed] {
-        fetchTrendingFeedsCallCount += 1
-        switch fetchTrendingFeedsResult {
-        case .success(let value): return value
-        case .failure(let error): throw error
-        }
+        try resolve(withLock { state.fetchTrendingFeedsCallCount += 1; return state.fetchTrendingFeedsResult })
     }
 
     public func fetchInterestFeeds() async throws(RepositoryError) -> InterestFeedState {
-        fetchInterestFeedsCallCount += 1
-        switch fetchInterestFeedsResult {
-        case .success(let value): return value
-        case .failure(let error): throw error
-        }
+        try resolve(withLock { state.fetchInterestFeedsCallCount += 1; return state.fetchInterestFeedsResult })
     }
 
     public func fetchPreferenceGenreNovels() async throws(RepositoryError) -> PreferenceGenreNovelState {
-        fetchRecommendedNovelsCallCount += 1
-        switch fetchRecommendedNovelsResult {
-        case .success(let value): return value
-        case .failure(let error): throw error
-        }
+        try resolve(withLock { state.fetchRecommendedNovelsCallCount += 1; return state.fetchRecommendedNovelsResult })
     }
 
     public func fetchSosoPick() async throws(RepositoryError) -> [SosoPick] {
-        fetchSosoPickCallCount += 1
-        switch fetchSosoPickResult {
-        case .success(let value): return value
-        case .failure(let error): throw error
-        }
+        try resolve(withLock { state.fetchSosoPickCallCount += 1; return state.fetchSosoPickResult })
     }
 
     public func fetchCachedNickname() -> String? {
-        fetchCachedNicknameCallCount += 1
-        return cachedNickname
+        withLock {
+            state.fetchCachedNicknameCallCount += 1
+            return state.cachedNickname
+        }
+    }
+
+    // MARK: - Helper
+
+    /// `NSLock`은 async 컨텍스트에서 직접 쓸 수 없어 동기 함수로 감싼다.
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+
+    private func resolve<T>(_ result: Result<T, RepositoryError>) throws(RepositoryError) -> T {
+        switch result {
+        case .success(let value): return value
+        case .failure(let error): throw error
+        }
     }
 }

--- a/Projects/Domain/RecommendationDomain/Tests/UseCase/LoadHomeDataUseCaseTests.swift
+++ b/Projects/Domain/RecommendationDomain/Tests/UseCase/LoadHomeDataUseCaseTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 kr.websoso.app. All rights reserved.
 //
 
+import Foundation
 import Testing
 @testable import RecommendationDomain
 @testable import BaseDomain
@@ -13,6 +14,22 @@ import Testing
 
 @Suite
 struct LoadHomeDataUseCaseTests {
+
+    // MARK: - 동시성
+
+    /// ⚠️ 이 테스트가 이 UseCase의 **퇴행 방지선**이다.
+    /// 과거 `async let`이 순차 `try await`로 펴진 적이 있고(c1e19ed0), 그때 아무 테스트도 깨지지 않아
+    /// 홈 로딩이 조용히 2~3배 느려졌다. 같은 시각에 겹쳐 있는 호출 수를 세서 병렬임을 못 박는다.
+    @Test("세 호출이 동시에 나간다 — 순차로 펴면 이 테스트가 깨진다")
+    func issuesThreeCallsConcurrently() async throws {
+        let probe = ConcurrencyProbeRepository()
+
+        let usecase = DefaultLoadHomeDataUseCase(repository: probe)
+        _ = try await usecase.execute()
+
+        // 순차라면 항상 1이다.
+        #expect(probe.peakConcurrentCalls == 3)
+    }
 
     // MARK: - 협력
 
@@ -123,17 +140,20 @@ struct LoadHomeDataUseCaseTests {
         }
     }
 
-    /// 순차 호출이라는 사실 자체가 명세다 — 병렬로 바꾸면 실패한 뒤에도 나머지 요청이 나간다.
-    @Test("앞선 호출이 실패하면 뒤따르는 호출과 닉네임 조회를 하지 않는다")
-    func stopsRemainingCallsAfterFailure() async {
+    /// 세 호출은 `async let`으로 동시에 나가므로 하나가 실패해도 나머지는 이미 출발해 있다.
+    /// 대신 **닉네임 조회는 세 결과를 다 받은 뒤**라 실패 시 수행되지 않는다 — 로컬 캐시 조회라
+    /// 굳이 당길 이유가 없고, 실패 경로에서 불필요한 부수효과를 남기지 않기 위해서다.
+    @Test("한 호출이 실패해도 나머지는 이미 나가 있고, 닉네임 조회는 하지 않는다")
+    func issuesAllCallsConcurrentlyAndSkipsNicknameOnFailure() async {
         let mock = MockRecommendationRepository()
         mock.fetchTodayDiscoveriesResult = .failure(RepositoryError.networkUnavailable)
 
         let usecase = DefaultLoadHomeDataUseCase(repository: mock)
         _ = try? await usecase.execute()
 
-        #expect(mock.fetchTrendingFeedsCallCount == 0)
-        #expect(mock.fetchRecommendedNovelsCallCount == 0)
+        #expect(mock.fetchTodayDiscoveriesCallCount == 1)
+        #expect(mock.fetchTrendingFeedsCallCount == 1)
+        #expect(mock.fetchRecommendedNovelsCallCount == 1)
         #expect(mock.fetchCachedNicknameCallCount == 0)
     }
 }
@@ -165,5 +185,66 @@ extension LoadHomeDataUseCaseTests {
             likeCount: 10,
             commentCount: 3
         )
+    }
+}
+
+// MARK: - 동시성 계측용 Repository
+
+/// 호출이 들어오고 나갈 때를 세어 **같은 시각에 몇 개가 겹쳐 있었는지**(`peakConcurrentCalls`)를 남긴다.
+/// 벽시계 시간을 재면 머신 부하에 흔들리지만, 겹친 개수는 병렬이면 3 / 순차면 1로 결정적이다.
+private final class ConcurrencyProbeRepository: RecommendationRepository, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var inFlight = 0
+    private var peak = 0
+
+    var peakConcurrentCalls: Int { withLock { peak } }
+
+    func fetchTodayDiscoveries() async throws(RepositoryError) -> [TodayDiscovery] {
+        await overlapping([])
+    }
+
+    func fetchTrendingFeeds() async throws(RepositoryError) -> [TrendingFeed] {
+        await overlapping([])
+    }
+
+    func fetchInterestFeeds() async throws(RepositoryError) -> InterestFeedState {
+        await overlapping(.noInterestSettings)
+    }
+
+    func fetchPreferenceGenreNovels() async throws(RepositoryError) -> PreferenceGenreNovelState {
+        await overlapping(.noGenreSettings)
+    }
+
+    func fetchSosoPick() async throws(RepositoryError) -> [SosoPick] {
+        await overlapping([])
+    }
+
+    func fetchCachedNickname() -> String? { nil }
+
+    /// 겹칠 틈을 만들기 위해 잠깐 머문다 — 이 지연이 없으면 셋 다 시작 전에 끝나버려 겹침이 안 잡힌다.
+    private func overlapping<T>(_ value: T) async -> T {
+        enter()
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        leave()
+        return value
+    }
+
+    private func enter() {
+        withLock {
+            inFlight += 1
+            peak = max(peak, inFlight)
+        }
+    }
+
+    private func leave() {
+        withLock { inFlight -= 1 }
+    }
+
+    /// `NSLock`은 async 컨텍스트에서 직접 쓸 수 없어 동기 함수로 감싼다.
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
     }
 }

--- a/Projects/Feature/HomeFeature/CLAUDE.md
+++ b/Projects/Feature/HomeFeature/CLAUDE.md
@@ -14,7 +14,9 @@
 ## 핵심 시나리오
 
 - **로드**: `onAppear`마다 `.load` → `LoadHomeDataUseCase`(추천 3종)와 `LoadUnreadNotificationStatusUseCase`
-  (알림 배지)를 **한 흐름**으로 부른다. 하나라도 실패하면 홈 전체가 실패다.
+  (알림 배지)를 **`async let`으로 동시에** 부른다. 하나라도 실패하면 홈 전체가 실패다.
+  추천 3종도 UseCase 안에서 동시 호출이라, 홈 진입 시 **총 4건이 한꺼번에 나간다**(순차로 펴지 말 것 →
+  [RecommendationDomain](../../Domain/RecommendationDomain/CLAUDE.md)에 퇴행 이력과 컴파일 함정이 있다).
 - **섹션 4개**: 검색바·상세검색 배너 / 오늘의 발견(가로 캐러셀) / {닉네임}님을 위한 추천글(2개씩 3페이지) /
   이 웹소설은 어때요?(2열 그리드, 선호장르 미설정이면 설정 유도 CTA).
 - 선택 결과는 전부 콜백으로 상위에 위임한다 — 이 화면은 스스로 화면을 전환하지 않는다.
@@ -58,6 +60,9 @@
 
 - 홈 Domain을 찾을 때 `HomeDomain`을 만들지 말 것 — 정본은 `RecommendationDomain/Sources/`다
   (`LibraryFeature`↔`NovelDomain`과 같은 형태의 이름 불일치).
+- **홈은 앱에서 손꼽히는 "동시 요청 4건" 지점**이다 → access token이 만료된 채 진입하면 **401도 4건이 동시에**
+  난다. 이걸 안전하게 만드는 건 `Networking`의 재발급 직렬화(`SessionRefreshCoordinator`)다 — 그게 없으면
+  재발급이 4번 나가 refresh token 회전 때문에 3건이 실패하고 로그아웃된다(#184).
 - ⚠️ **`.load`에 "최초 1회" 가드를 넣지 말 것** — 홈은 밖(피드 작성·선호장르 설정·알림 확인)에서 바뀐 값을
   다시 비춰야 해서 **탭 복귀마다 갱신**하기로 정했다(구 WSSiOS도 `viewWillAppear`마다 전체를 다시 불렀다).
   중복 요청은 `loadTask` 가드가 막는다. `LibraryFeature`의 `hasLoaded` 패턴을 그대로 옮겨오지 말 것.

--- a/Projects/Feature/HomeFeature/Sources/Home/HomeViewModel.swift
+++ b/Projects/Feature/HomeFeature/Sources/Home/HomeViewModel.swift
@@ -128,20 +128,29 @@ private extension HomeViewModel {
         defer { state.isLoading = false }
 
         do {
-            let homeData = try await loadHomeDataUseCase.execute()
-            let notificationStatus = try await loadUnreadNotificationStatusUseCase.execute()
+            // 둘은 서로 독립이라 동시에 부른다 — 순차로 펴면 왕복 지연이 그대로 더해지는데,
+            // 홈은 탭 복귀마다 갱신하는 화면이라 그 비용을 매번 낸다.
+            async let homeData = loadHomeDataUseCase.execute()
+            async let notificationStatus = loadUnreadNotificationStatusUseCase.execute()
+
+            let loadedHomeData = try await homeData
+            let loadedNotificationStatus = try await notificationStatus
 
             // 플래그를 state보다 **먼저** 올린다 — 관찰 대상이 아니라 갱신을 스스로 트리거하지 않으므로,
             // 뷰를 깨우는 state 대입 시점에 이미 최신값이어야 한다(아래 실패 경로도 같은 이유로 먼저 내린다).
             hasLoadedContent = true
 
-            state.nickname = homeData.nickname
-            state.todayDiscoveries = homeData.todayDiscoveries
-            state.trendingFeeds = homeData.trendingFeeds
-            state.preferenceGenreNovelState = homeData.preferenceGenreNovelState
-            state.hasUnreadNotifications = notificationStatus.hasUnreadNotifications
-        } catch {
+            state.nickname = loadedHomeData.nickname
+            state.todayDiscoveries = loadedHomeData.todayDiscoveries
+            state.trendingFeeds = loadedHomeData.trendingFeeds
+            state.preferenceGenreNovelState = loadedHomeData.preferenceGenreNovelState
+            state.hasUnreadNotifications = loadedNotificationStatus.hasUnreadNotifications
+        } catch let error as RepositoryError {
             presentLoadFailure(error)
+        } catch {
+            // ⚠️ `async let`이 UseCase의 타입 지정 throw를 `any Error`로 지워서 분기가 필요하다.
+            // 두 UseCase 모두 RepositoryError만 던지므로 여기는 실제로는 도달하지 않는다.
+            presentLoadFailure(.unknown)
         }
     }
 }

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -73,6 +73,11 @@ import WSSComponent       // UI
 root `CLAUDE.md` Non-negotiable #2가 **정본**. 여기선 **throwing 규약만** 다룬다:
 
 - Domain/Data의 throwing은 **typed throws** (`throws(RepositoryError)`, 로그인만 `throws(AuthError)`).
+- ⚠️ **`async let`·`withThrowingTaskGroup`은 typed throws를 `any Error`로 지운다** → `throws(RepositoryError)`
+  함수 안에서 수확하면 컴파일이 깨진다. **병렬성을 포기하고 순차로 펴는 게 아니라** `do/catch`로 되돌린다
+  (`catch let error as RepositoryError { throw error } catch { throw .unknown }`).
+  실제로 이걸 피하려다 홈 로드가 순차로 퇴행한 적이 있다 — 경위·대안 검토는
+  [RecommendationDomain](../Projects/Domain/RecommendationDomain/CLAUDE.md)에 남겼다.
 
 ## 에러 처리 계약
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -106,11 +106,44 @@
   **둘 다 `.authenticationRequired`로** 보낸다. 상위에서는 "그냥 401이 왔다"와 "재발급을 시도했는데 세션이 죽었다"를
   구분할 수 없다.
 - **결과**: 재시도 상한(요청당 재발급 2회)을 다 쓰고 나온 401이 진짜 세션 만료와 똑같이 취급되어 **로그인 화면으로 튕긴다.**
-  `.authenticationRequired`를 받아 로그인 라우팅을 거는 ViewModel이 현재 6곳이다
-  (`HomeViewModel`·`LibraryViewModel`·`UserLibraryViewModel`·`NovelDetailViewModel`·`NovelReviewViewModel`·`NotificationListViewModel` 등).
+  `.authenticationRequired`를 받아 로그인 라우팅을 거는 ViewModel이 여럿이다
+  (`HomeViewModel`·`LibraryViewModel`·`UserLibraryViewModel`·`NovelDetailViewModel`·`NovelReviewViewModel` — 착수 시
+  `rg "requiresAuthentication = true"`로 다시 세어볼 것. 화면이 늘면 자동으로 늘어난다).
 - **어디를 고치나**: `Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift` +
-  `RepositoryError`에 케이스를 나눌지 결정 → 소비하는 ViewModel 6곳의 분기.
+  `RepositoryError`에 케이스를 나눌지 결정 → 소비하는 ViewModel 전부의 분기.
 - **왜 지금 안 했나**: #184는 중복 재발급 자체를 없애는 범위였다. 세 겹 방어(coalescing·토큰 세대 비교·세션 종료 판정 분리)로
   **이 경로에 도달하는 빈도 자체가 매우 낮아졌고**, 에러 타입을 쪼개면 Data·Feature 여러 모듈의 테스트를 다시 돌려야 한다.
 - **놓치기 쉬운 것**: 값을 쪼개는 게 목적이 아니라 **"어디까지를 로그아웃으로 볼 것인가"** 라는 UX 결정이 먼저다.
   결론이 나면 그 결론을 `Projects/Core/Networking/CLAUDE.md`와 `Projects/Data/BaseData/CLAUDE.md`에 못 박을 것.
+
+### 6. 병렬 로드에서 인증 만료가 다른 에러에 가려질 수 있다
+
+- **무엇**: `HomeViewModel.load()`가 홈 데이터와 알림 상태를 `async let`으로 동시에 부르고 **앞의 것을 먼저 `await`** 한다.
+  홈 데이터가 `.serverUnavailable`, 알림이 `.authenticationRequired`를 동시에 던지면 앞의 에러만 잡혀
+  전면 실패 뷰가 뜨고 **로그인 라우팅은 걸리지 않는다**(Feature 레이어의 "인증 만료는 어느 catch든 로그인 라우팅" 계약 위반).
+- **결과**: 세션이 죽었는데 "네트워크 오류" 화면에서 재시도만 반복하게 된다.
+- **어디를 고치나**: `Projects/Feature/HomeFeature/Sources/Home/HomeViewModel.swift`의 병렬 로드 블록.
+  같은 모양이 다른 화면에 복사되면 함께 본다.
+- **왜 지금 안 했나**: **기존 순차 코드도 우선순위는 같았다**(홈 데이터가 먼저 실패하면 알림은 아예 호출되지 않았다) —
+  #184의 병렬화가 만든 회귀가 아니다. 세션이 죽으면 홈 데이터도 401을 받으므로 실제 발생 조건이 드물고,
+  고치려면 두 결과를 `Result`로 수확해야 하는데 **이 레포는 `Result` 사용을 지양한다.**
+- **놓치기 쉬운 것**: `Result` 없이 풀려면 인증 만료를 먼저 판정할 다른 수단(에러 우선순위 비교, 또는 UseCase 쪽에서 합치기)이
+  필요하다. `LoadHomeDataUseCase` 내부의 3개 병렬 호출도 같은 성질을 가지므로 함께 결정할 것.
+
+### 7. 재시도로 복구되는 실패와 아닌 실패가 같은 화면으로 보인다
+
+- **무엇**: `NetworkErrorView`의 문구가 **"네트워크 연결에 실패했어요 / 연결 상태를 확인한 후 다시 시도해 보세요"로 고정**이다.
+  서버 5xx(`.serverUnavailable`)로 실패해도 같은 화면이 뜬다.
+- **결과**: 원인을 **틀리게** 알려준다. 서버가 죽은 건데 사용자는 자기 와이파이를 껐다 켜며 헤맨다.
+  반대로 진짜 연결 문제일 때와 구분이 안 돼 "기다리면 되는지 / 내가 뭘 해야 하는지"를 판단할 근거가 없다.
+- **어디를 고치나**: `Projects/UI/WSSComponent/Sources/Network/NetworkErrorView.swift` +
+  각 ViewModel이 `RepositoryError`의 원인을 화면까지 넘기는 배관.
+  ⚠️ **공용 컴포넌트다** — 홈뿐 아니라 서재·작품 상세·리뷰 등 실패 화면이 전부 이걸 쓴다. API를 바꾸면 전 화면을 훑어야 한다.
+- **왜 지금 안 했나**: #184는 재발급 중복 제거 범위였고, 무엇보다 **"서버 오류" 상태의 디자인 시안이 없다**(2026-08-22 확인).
+  문구·일러스트를 임의로 지어내면 디자인과 어긋난다 → 시안이 나온 뒤 착수한다.
+- **놓치기 쉬운 것**:
+  - **값은 이미 있다** — `RepositoryError`가 `networkUnavailable`과 `serverUnavailable`로 나뉘어 있는데 화면이 안 쓰고 있을 뿐이다.
+    새 에러 타입을 만들 일이 아니다.
+  - ⚠️ **`/reissue`가 5xx일 때 지금은 로그인 화면으로 보낸다**(재인증 갈래 — `Projects/Core/Networking/CLAUDE.md`의 표).
+    서버 장애면 다시 로그인해도 실패하므로 "잠시 후 다시" 쪽이 옳을 수 있는데, **뷰가 갈리지 않은 상태에서 갈래만 바꾸면**
+    "네트워크 연결에 실패했어요"라는 틀린 문구를 보게 된다. **뷰 분기가 먼저이고, 그때 이 갈래도 함께 결정한다.**

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -100,3 +100,17 @@
   Xcode 프로젝트가 통째로 바뀌는 이관이라 **반드시 실측 검증**할 것 — 추측으로 넘어가지 말 것. Push
   (APNs)·Universal Link(`apple-app-site-association`) 등 Bundle ID에 종속된 다른 설정이 운영 앱에
   더 있다면 같은 시점에 함께 점검 대상.
+### 5. 401과 "재발급까지 해봤지만 실패"가 Data 레이어에서 구분되지 않는다
+
+- **무엇**: `NetworkingError+RepositoryError.swift`가 `responseFailure(401)`과 `requiresReauthentication`을
+  **둘 다 `.authenticationRequired`로** 보낸다. 상위에서는 "그냥 401이 왔다"와 "재발급을 시도했는데 세션이 죽었다"를
+  구분할 수 없다.
+- **결과**: 재시도 상한(요청당 재발급 2회)을 다 쓰고 나온 401이 진짜 세션 만료와 똑같이 취급되어 **로그인 화면으로 튕긴다.**
+  `.authenticationRequired`를 받아 로그인 라우팅을 거는 ViewModel이 현재 6곳이다
+  (`HomeViewModel`·`LibraryViewModel`·`UserLibraryViewModel`·`NovelDetailViewModel`·`NovelReviewViewModel`·`NotificationListViewModel` 등).
+- **어디를 고치나**: `Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift` +
+  `RepositoryError`에 케이스를 나눌지 결정 → 소비하는 ViewModel 6곳의 분기.
+- **왜 지금 안 했나**: #184는 중복 재발급 자체를 없애는 범위였다. 세 겹 방어(coalescing·토큰 세대 비교·세션 종료 판정 분리)로
+  **이 경로에 도달하는 빈도 자체가 매우 낮아졌고**, 에러 타입을 쪼개면 Data·Feature 여러 모듈의 테스트를 다시 돌려야 한다.
+- **놓치기 쉬운 것**: 값을 쪼개는 게 목적이 아니라 **"어디까지를 로그아웃으로 볼 것인가"** 라는 UX 결정이 먼저다.
+  결론이 나면 그 결론을 `Projects/Core/Networking/CLAUDE.md`와 `Projects/Data/BaseData/CLAUDE.md`에 못 박을 것.


### PR DESCRIPTION
## 💡 Issue
- closed #184

<br>

## 💭 Summary
401이 동시에 여러 건 나면 토큰 재발급도 그만큼 중복 실행돼, 이미 회전된 refresh token으로 재발급을 시도하다 **유효한 토큰까지 지워지고 로그인 화면으로 튕기던** 문제를 고쳤습니다. 재발급을 단일 in-flight 작업으로 합치고, 재발급이 실패했을 때 "정말 세션이 끝난 것인지"를 성격별로 갈라 판정합니다.

<br>

## 🔑 Key Changes

### Core/Networking — 재발급 직렬화 (핵심)
`SessionRefreshCoordinator`(actor)를 신설해 세 겹으로 막습니다.

1. **coalescing** — 진행 중인 재발급 Task를 공유합니다. 동시 401 N건이 재발급 1회로 합쳐집니다.
2. **토큰 세대 비교** — 요청이 헤더에 담았던 access token이 저장소의 것과 다르면 이미 남이 갱신한 것이므로, **재발급 없이** 새 토큰으로 바로 재시도합니다. coalescing만으로는 "갱신 직후 도착한 401"을 못 잡습니다.
3. **재발급 실패 판정 3분화** — 실패의 성격에 따라 토큰 처리를 다르게 합니다.

| refresh가 실패한 방식 | 토큰 | 상위로 나가는 것 |
|---|---|---|
| `401` — 서버가 refresh token 자체를 거절 | **삭제** | `requiresReauthentication` |
| 그 밖의 HTTP 응답 실패 / 응답 파싱 실패 | **보존** | `requiresReauthentication` |
| 통신 실패·타임아웃 | 보존 | 원래 에러 그대로 전파 |

`NetworkingClient`는 재시도 카운터(`maxAuthRetries`)로 무한 루프를 막고, 헤더에 **실제로 담은 토큰**을 컨텍스트로 넘겨 세대 비교가 가능하게 했습니다.

### Domain / Feature — 홈 로드 병렬 복구
- `LoadHomeDataUseCase`: 3개 호출을 `async let`으로 되돌렸습니다. 과거 `c1e19ed0`(throws 타입 통일)에서 순차로 퇴행했던 것으로, 컴파일 함정을 피하려다 딸려온 부수 피해였습니다. (실측: 순차 0.34~0.52s ↔ 병렬 0.16~0.19s)
- `HomeViewModel`: 홈 데이터와 알림 배지를 동시에 부릅니다.

### 테스트
- 동시 401 5건 → 재발급 1회 / 이미 갱신된 뒤 도착한 401 / 재시도 상한 도달 / 재발급 실패 3종(401·404·파싱 실패) / 통신 실패 시 토큰 보존
- `Networking` 27건, `RecommendationDomain` 33건 전부 통과

<br>

## 📱 Simulation
화면 변경이 없는 배관·성능 수정이라 해당 없습니다. 실앱에서의 재인증 경로 검증 결과와 **재현 레시피**는 `Projects/Core/Networking/CLAUDE.md`에 남겼습니다.

<br>

## 🧑‍🧒‍🧒 To Reviewer
1. **"재발급 실패를 어디까지 로그아웃으로 볼 것인가"** 가 이 PR의 핵심 판단입니다. 통신 실패로 로그아웃시키면 지하철에서 잠깐 끊겼다고 튕기고(이전 버그), 응답을 받고도 로그인으로 안 보내면 401만 반복됩니다. 위 표가 그 경계입니다.
2. **토큰 삭제는 401에서만** 합니다. 5xx 같은 일시 장애에서 지우면 서버가 복구돼도 세션을 되살릴 방법이 없습니다.
3. `maxAuthRetries = 2`는 오타가 아닙니다 — 토큰 세대 비교로 재시도하는 경로가 카운터를 한 번 쓰기 때문에, 1로 줄이면 그 요청이 실제 재발급 기회를 잃습니다.
4. ⚠️ **App 조립 시**: 인증이 필요한 `NetworkingClient`는 **앱 전체에서 하나를 공유**해야 합니다. coordinator가 client마다 생기므로 화면·모듈마다 새로 만들면 직렬화가 무의미해집니다.
5. **`5xx`도 로그인 화면으로 갑니다.** 서버 장애면 다시 로그인해도 실패하니 "잠시 후 다시" 쪽이 옳아 보이지만, `NetworkErrorView`의 문구가 "네트워크 연결에 실패했어요"로 고정이라 갈래만 바꾸면 **틀린 원인을 알려주게** 됩니다. 뷰 문구 분기가 먼저라 판단해 `docs/TODO.md` 7번으로 남겼습니다("서버 오류" 디자인 시안이 아직 없습니다).
6. 범위 밖이라 미룬 것 3건은 `docs/TODO.md` 5·6·7번에 배경과 함께 남겼습니다.

<br>

## ※ Reference
- 홈이 "동시 요청 4건" 지점이라 이 버그의 재현 무대가 됩니다 — `Projects/Feature/HomeFeature/CLAUDE.md`
