### PR TITLE
[Setting] #206 - 테스트·전체빌드 선결 블로커 해소 (Logger demo 제거·testDependencies·공유 Mock)

### DIFF
--- a/Projects/Core/Logger/Demo/Demo.swift
+++ b/Projects/Core/Logger/Demo/Demo.swift
@@ -1,7 +1,0 @@
-//
-//  Demo.swift
-//  Manifests
-//
-//  Created by Seoyeon Choi on 11/10/25.
-//
-

--- a/Projects/Core/Logger/Project.swift
+++ b/Projects/Core/Logger/Project.swift
@@ -11,5 +11,5 @@ import DependencyPlugin
 
 let project = Project.createCoreModule(
     name: ModuleType.core(.logger).name,
-    targets: [.sources, .demo]
+    targets: [.sources]
 )

--- a/Projects/Domain/NovelReviewDomain/Testing/Mock/MockLoadNovelReviewDraftUseCase.swift
+++ b/Projects/Domain/NovelReviewDomain/Testing/Mock/MockLoadNovelReviewDraftUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  MockLoadNovelReviewDraftUseCase.swift
+//  NovelReviewDomain
+//
+//  Created by Codex on 8/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import NovelReviewDomain
+import BaseDomain
+
+/// Feature ViewModel 테스트용 공유 Mock — 결과는 `loadResult`로 주입, 입력은 `loadedNovelIDs`로 추적한다.
+/// (비동기 경합처럼 "실행을 멈춰 세워야 하는" 특수 시나리오는 각 테스트가 전용 fake를 따로 둔다.)
+public final class MockLoadNovelReviewDraftUseCase: LoadNovelReviewDraftUseCase {
+    public var loadResult: Result<NovelReviewDraft?, RepositoryError> = .success(nil)
+    public private(set) var loadedNovelIDs: [NovelID] = []
+
+    public init() {}
+
+    public func execute(novelID: NovelID) async throws(RepositoryError) -> NovelReviewDraft? {
+        loadedNovelIDs.append(novelID)
+        switch loadResult {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/Projects/Domain/NovelReviewDomain/Testing/Mock/MockSaveNovelReviewUseCase.swift
+++ b/Projects/Domain/NovelReviewDomain/Testing/Mock/MockSaveNovelReviewUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  MockSaveNovelReviewUseCase.swift
+//  NovelReviewDomain
+//
+//  Created by Codex on 8/25/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import NovelReviewDomain
+import BaseDomain
+
+/// Feature ViewModel 테스트용 공유 Mock — 결과는 `saveResult`로 주입, 저장 호출은 `savedDrafts`로 추적한다.
+public final class MockSaveNovelReviewUseCase: SaveNovelReviewUseCase {
+    public var saveResult: Result<Void, RepositoryError> = .success(())
+    public private(set) var savedDrafts: [NovelReviewDraft] = []
+
+    public init() {}
+
+    public func execute(draft: NovelReviewDraft) async throws(RepositoryError) {
+        savedDrafts.append(draft)
+        switch saveResult {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/Projects/Feature/NovelReviewFeature/Project.swift
+++ b/Projects/Feature/NovelReviewFeature/Project.swift
@@ -26,5 +26,10 @@ let project = Project.createFeatureModule(
         .module(.data(.novelReview)),
         .module(.data(.base)),
         .module(.core(.networking))
+    ],
+    // ViewModel 테스트가 NovelReviewDomainTesting의 공유 Mock UseCase를 import 하게 한다
+    // (Mock UseCase는 UseCase 프로토콜이 선언된 Domain의 Testing 타깃에 둔다 — Repository Mock과 같은 자리).
+    testDependencies: [
+        .module(.domain(.novelReview), type: .testing)
     ]
 )

--- a/Projects/Feature/NovelReviewFeature/Tests/NovelReview/NovelReviewViewModelTests.swift
+++ b/Projects/Feature/NovelReviewFeature/Tests/NovelReview/NovelReviewViewModelTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 import BaseDomain
 import NovelReviewDomain
+import NovelReviewDomainTesting
 @testable import NovelReviewFeature
 
 @MainActor
@@ -93,13 +94,13 @@ struct NovelReviewViewModelTests {
 private extension NovelReviewViewModelTests {
     func makeViewModel(
         status: ReadingStatus = .watching,
-        loadUseCase: LoadNovelReviewDraftUseCase = ImmediateLoadNovelReviewDraftUseCase(result: nil)
+        loadUseCase: LoadNovelReviewDraftUseCase = MockLoadNovelReviewDraftUseCase()
     ) -> NovelReviewViewModel {
         NovelReviewViewModel(
             novelID: NovelID(1),
             status: status,
             loadUseCase: loadUseCase,
-            saveUseCase: NoopSaveNovelReviewUseCase()
+            saveUseCase: MockSaveNovelReviewUseCase()
         )
     }
 
@@ -120,14 +121,8 @@ private extension NovelReviewViewModelTests {
     }
 }
 
-private struct ImmediateLoadNovelReviewDraftUseCase: LoadNovelReviewDraftUseCase {
-    let result: NovelReviewDraft?
-
-    func execute(novelID: NovelID) async throws(RepositoryError) -> NovelReviewDraft? {
-        result
-    }
-}
-
+// 비동기 경합 검증 전용 fake — "실행을 멈춰 세운 뒤 원할 때 완료"시키는 특수 동작이라
+// 공유 Mock(MockLoadNovelReviewDraftUseCase)으로는 대체되지 않아 이 파일에 남긴다.
 private final class SuspendedLoadNovelReviewDraftUseCase: LoadNovelReviewDraftUseCase {
     private var resultContinuation: CheckedContinuation<NovelReviewDraft?, Never>?
     private var startContinuation: CheckedContinuation<Void, Never>?
@@ -152,8 +147,4 @@ private final class SuspendedLoadNovelReviewDraftUseCase: LoadNovelReviewDraftUs
         resultContinuation?.resume(returning: result)
         resultContinuation = nil
     }
-}
-
-private struct NoopSaveNovelReviewUseCase: SaveNovelReviewUseCase {
-    func execute(draft: NovelReviewDraft) async throws(RepositoryError) {}
 }

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -121,6 +121,7 @@ extension Project {
         internalDependencies: [TargetDependency] = [],
         externalDependencies: [TargetDependency] = [],
         demoDependencies: [TargetDependency] = [],
+        testDependencies: [TargetDependency] = [],
         demoEntitlements: Entitlements? = nil
     ) -> Project {
 
@@ -133,7 +134,7 @@ extension Project {
             internalDependencies: internalDependencies,
             externalDependencies: externalDependencies,
             demoDependencies: demoDependencies,
-            testDependencies: [],
+            testDependencies: testDependencies,
             deploymentTarget: env.deploymentTarget,
             infoPlist: ModuleInfoPlist.feature.infoPlist,
             demoInfoPlist: ModuleInfoPlist.featureDemo.infoPlist,
@@ -193,9 +194,10 @@ extension Project {
         name: String,
         targets: Set<TargetType>,
         internalDependencies: [TargetDependency] = [],
-        externalDependencies: [TargetDependency] = []
+        externalDependencies: [TargetDependency] = [],
+        testDependencies: [TargetDependency] = []
     ) -> Project {
-        
+
         let allTargets = makeBaseTargets(
             name: name,
             product: .framework,
@@ -205,7 +207,7 @@ extension Project {
             internalDependencies: internalDependencies,
             externalDependencies: externalDependencies,
             demoDependencies: [],
-            testDependencies: [],
+            testDependencies: testDependencies,
             deploymentTarget: env.deploymentTarget,
             infoPlist: ModuleInfoPlist.data.infoPlist
         )
@@ -228,7 +230,8 @@ extension Project {
         name: String,
         targets: Set<TargetType>,
         internalDependencies: [TargetDependency] = [],
-        externalDependencies: [TargetDependency] = []
+        externalDependencies: [TargetDependency] = [],
+        testDependencies: [TargetDependency] = []
     ) -> Project {
 
         let allTargets = makeBaseTargets(
@@ -240,7 +243,7 @@ extension Project {
             internalDependencies: internalDependencies,
             externalDependencies: externalDependencies,
             demoDependencies: [],
-            testDependencies: [],
+            testDependencies: testDependencies,
             deploymentTarget: env.deploymentTarget,
             infoPlist: ModuleInfoPlist.core.infoPlist
         )
@@ -264,7 +267,8 @@ extension Project {
         targets: Set<TargetType>,
         internalDependencies: [TargetDependency] = [],
         externalDependencies: [TargetDependency] = [],
-        demoDependencies: [TargetDependency] = []
+        demoDependencies: [TargetDependency] = [],
+        testDependencies: [TargetDependency] = []
     ) -> Project {
 
         let allTargets = makeBaseTargets(
@@ -276,7 +280,7 @@ extension Project {
             internalDependencies: internalDependencies,
             externalDependencies: externalDependencies,
             demoDependencies: demoDependencies,
-            testDependencies: [],
+            testDependencies: testDependencies,
             deploymentTarget: env.deploymentTarget,
             infoPlist: ModuleInfoPlist.ui.infoPlist
         )

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -147,3 +147,29 @@
   - ⚠️ **`/reissue`가 5xx일 때 지금은 로그인 화면으로 보낸다**(재인증 갈래 — `Projects/Core/Networking/CLAUDE.md`의 표).
     서버 장애면 다시 로그인해도 실패하므로 "잠시 후 다시" 쪽이 옳을 수 있는데, **뷰가 갈리지 않은 상태에서 갈래만 바꾸면**
     "네트워크 연결에 실패했어요"라는 틀린 문구를 보게 된다. **뷰 분기가 먼저이고, 그때 이 갈래도 함께 결정한다.**
+
+### 8. 피드 공개범위(`VisibilityType`) 변환이 Repository와 Service로 이중으로 쪼개져 있다
+
+- **무엇**: `MyFeedOption.visibilityType`(Domain enum, 3-값: `privateOnly`/`publicOnly`/`all`)이 서버 파라미터로 가기까지
+  **두 계층에서 두 번** 변환된다.
+  1. `DefaultFeedRepository.fetchMyFeeds`가 `FeedMapper.visibilityString(from:)`으로 enum → 문자열(`"PUBLIC"`/`"PRIVATE"`/`"ALL"`)
+  2. `DefaultFeedService.getMyFeeds`가 그 문자열을 다시 `isVisible: Bool?` / `isUnVisible: Bool?`로
+     (`visibilityType == "PUBLIC" ? true : nil`)
+  중간의 문자열은 Repository→Service 전달용 임시 표현일 뿐이고, 최종 쿼리 파라미터 매핑이 **Service로 새어나가 있다.**
+- **결과(냄새·잠재 버그)**:
+  - 계층 책임 위반 — 요청 파라미터 매핑은 Repository/`FeedMapper`에 모여야 하는데 유독 이 파생만 Service에 있다(다른 메서드는 통과 계층).
+  - `"ALL"`을 Service가 **명시적으로 다루지 않는다**(둘 다 nil로 떨어져 우연히 맞음). enum→문자열로 낮춰서
+    **`switch` 누락 검사를 컴파일러가 못 한다** — 서버 스펙이 바뀌거나 오타가 나면 조용히 "전체"로 처리된다.
+  - **테스트 사각지대** — Service 단위 테스트가 없고 Repository 테스트는 Service를 mock하니, 이 `문자열→Bool?` 변환은
+    어느 테스트도 지나가지 않는다.
+- **어디를 고치나**: 매핑을 한 곳으로 모은다 — Repository(또는 `FeedMapper`)가 `VisibilityType` enum → 완성된 쿼리 값까지
+  한 번에 만들고, `DefaultFeedService.getMyFeeds`는 **판단 없이 통과**시킨다. `Projects/Data/FeedData/Sources/Service/DefaultFeedService.swift`
+  + `.../Repository/DefaultFeedRepository.swift` + `.../Mapper/FeedMapper.swift`.
+  ⚠️ **다른 Feed Service 메서드도 Query를 Service 안에서 조립**한다(`getNovelFeeds` 등) → "Query 조립은 Repository, Service는 통과"를
+  **컨벤션으로 먼저 정하고** 함께 옮겨야 한다. 한 메서드만 바꾸면 두 벌로 갈린다.
+- **왜 지금 안 했나**: 테스트 체계 정비(지도 이슈) 논의 중 발견한 별건이다. 지금 동작은 정상이라 급하지 않고,
+  컨벤션 결정이 선행돼야 해서 분리한다.
+- **놓치기 쉬운 것**: 이건 **자동 검사의 사각지대 표본**이다 — "매핑은 어느 계층 소관인가"는 의미 판단이라 린터로 못 잡고,
+  지금 리뷰어 눈에도 안 띄어 통과했다. 근본 예방책은 **타입을 좁혀 leak을 문법적으로 불가능하게** 만드는 것
+  (Service가 `String` 대신 완성된 Query를 받으면 변환할 거리가 없어진다). 정적 검사로는 "Service 파일에 분기(`if`/`switch`/`?:`) 금지"가
+  싼 그물이 된다(지도 이슈 A2 후보).


### PR DESCRIPTION
## 💡 Issue

- closed #206

<br>

## 💭 Summary

테스트·전체빌드 체계의 **선결 블로커**를 해소한다 — 지도 이슈 #205의 축 A / A0. 이게 풀려야 PR 자동 CI(A1)·Feature ViewModel TDD(B2)를 착수할 수 있다.

<br>

## 🔑 Key Changes

**1. Logger의 demo 타깃 제거** (`[Del]`)
- `Demo/Demo.swift`가 헤더 주석뿐이라 `LoggerDemo` 앱에 `@main`이 없어 `Undefined symbols: _main`으로 링크가 깨지고, `tuist build`(전체 빌드)가 Logger 스킴에서 멈췄다(`BUILD_AND_TEST.md` 함정 11).
- Logger는 UI 없는 순수 로깅 유틸이라 데모가 보여줄 게 없다 → 빈 스텁을 채우는 대신 **demo 타깃 자체를 제거**(`targets: [.sources]`). 아무도 `LoggerDemo`에 의존하지 않음을 확인. 빈 스텁 문제가 원천적으로 사라진다.

**2. `create*Module`에 `testDependencies` 개방 + Feature 테스트를 공유 Mock UseCase로 전환** (`[Setting]`)
- `create{Feature,Data,Core,UI}Module`이 `makeBaseTargets(testDependencies: [])`로 **하드코딩**돼 있어(Domain만 통과) Feature 테스트가 `~DomainTesting`(Mock)을 import 못 했다. 파라미터를 열어 전달 — 기본값 `[]`라 기존 호출부 무영향.
- `NovelReviewDomainTesting`에 공유 Mock UseCase 2개 추가(`MockNovelReviewRepository`와 동일 패턴 — tracking 배열 + `Result` 주입 + typed throws): `MockLoadNovelReviewDraftUseCase`, `MockSaveNovelReviewUseCase`.
- `NovelReviewFeature`에 `testDependencies: [.module(.domain(.novelReview), type: .testing)]` 배선.
- `NovelReviewViewModelTests`가 파일 안에서 손수 만든 `ImmediateLoad`/`NoopSave` 로컬 fake를 공유 Mock으로 대체. (`SuspendedLoad`는 비동기 경합 전용 특수 fake라 로컬 유지)

**3. TODO 기록** (`[Docs]`, 별건)
- 작업 중 발견한 `DefaultFeedService.getMyFeeds`의 공개범위 이중 변환 결함을 `docs/TODO.md` 8번으로 남김(이번 PR에서 고치지 않음).

**미룸**: A0의 ④번(모듈별 빌드 세팅 주입 경로)은 소비처(Swift 6)가 없어 지금 뚫으면 검증 안 되는 빈 통로가 되므로 **A4로 이관**(이슈 #206에 표기).

<br>

## 📱 Simulation

해당 없음 (UI 변경 없음 — 매니페스트·테스트·Domain Testing Mock 변경).

<br>

## 🧑‍🧒‍🧒 To Reviewer

- **검증 완료**: `build_sim(Logger)` — `-scheme Logger` 실빌드, `Logger.framework` 링크, BUILD SUCCEEDED / `test_sim(NovelReviewFeature)` 5/5 통과. 공유 Mock 경로가 실제로 물리는지 **단언 하나를 일부러 뒤집어 red(1 failed) 관측 후 원복**해 확인(동어반복 아님).
- **첫 사용처 증명**입니다 — Mock UseCase는 `NovelReview` 하나만 만들었고, 나머지 화면(Home/Library/NovelDetail placeholder)은 후속 이슈에서 같은 방식으로 확장합니다. **전부 만들지 않은 건 의도**(쓰는 것부터).
- `create*Module` 4개에 파라미터를 더했지만 **기본값 `[]`라 기존 모듈 매니페스트는 영향 없음**(NovelReviewFeature만 실제로 사용).

<br>

## ※ Reference

- 지도 이슈: #205 (AI 검증 체계 — 축 A / A0)
