### PR TITLE
[Test] #210 - A1이 드러낸 기존 테스트 실패 4개 정리

### DIFF
--- a/Projects/Data/ProfileData/Tests/DefaultProfileRepositoryTests.swift
+++ b/Projects/Data/ProfileData/Tests/DefaultProfileRepositoryTests.swift
@@ -130,7 +130,7 @@ struct DefaultProfileRepositoryTests {
                 intro: "소개글",
                 avatarImage: "",
                 isProfilePublic: nil,
-                genrePreferences: ["ROMANCE"]
+                genrePreferences: ["romance"]
             )
         )
 

--- a/Projects/Domain/AuthDomain/Tests/UseCase/SyncAppleCredentialUseCaseTests.swift
+++ b/Projects/Domain/AuthDomain/Tests/UseCase/SyncAppleCredentialUseCaseTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 @testable import AuthDomain
 import AuthDomainTesting
+import BaseDomain
 
 @Suite("SyncAppleCredentialUseCase")
 struct SyncAppleCredentialUseCaseTests {

--- a/Projects/Domain/ProfileDomain/Tests/UseCase/LoadNovelPreferencesUseCaseTests.swift
+++ b/Projects/Domain/ProfileDomain/Tests/UseCase/LoadNovelPreferencesUseCaseTests.swift
@@ -59,6 +59,7 @@ private final class StubKeywordRepository: KeywordRepository {
     func fetchKeywords() async throws(RepositoryError) -> [KeywordGroup] { [] }
     func searchKeywords(_ query: String) async throws(RepositoryError) -> [KeywordGroup] { [] }
     func syncKeywords() async {}
+    func fetchPopularKeywords() async throws(RepositoryError) -> PopularKeywords { PopularKeywords(keywords: []) }
 }
 
 extension LoadNovelPreferencesUseCaseTests {

--- a/Projects/Feature/SettingFeature/Project.swift
+++ b/Projects/Feature/SettingFeature/Project.swift
@@ -12,7 +12,7 @@ import DependencyPlugin
 
 let project = Project.createFeatureModule(
     name: ModuleType.feature(.setting).name,
-    targets: [.sources, .demo, .tests],
+    targets: [.sources, .demo],
     internalDependencies: [
         .module(.domain(.base)),
         .module(.domain(.profile)),

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -150,7 +150,7 @@
 
 ### 8. PR CI가 매번 전체 모듈을 돌린다 — 변경 영향권만 도는 선택적 테스트(Tuist)로 최적화
 
-- **무엇**: A1(#208)에서 `.github/workflows/test.yml`이 PR마다 `.tests`를 선언한 정식 모듈 30개 **전부**를
+- **무엇**: A1(#208)에서 `.github/workflows/test.yml`이 PR마다 `.tests`를 선언한 정식 모듈 **전부**를
   `xcodebuild test`로 병렬 실행한다. 이번 변경과 무관한 모듈도 매번 돈다.
 - **결과**: 문서·한 모듈만 바꾼 PR도 macOS 러너 30대를 쓴다 — 첫 실행 20~40분+, 비용·동시성 부담.
   Tuist/DerivedData 캐시로 완화되지만 근본적으로 낭비다.
@@ -169,3 +169,9 @@
   (2026-08-25, 지도 이슈 #205 축 A 후속).
 - **놓치기 쉬운 것**: 선택적 테스트의 목적은 "빠르다"가 아니라 **"정확히 영향권만"** 이다. 영향권 계산이 틀리면
   빠른 대신 거짓 초록을 낸다 — 속도보다 의존성 전파 정확도가 우선이다.
+
+### 9. SettingFeature에 VM 테스트가 없다 (`.tests` 선언을 되돌림)
+
+- **무엇**: SettingFeature는 `.tests`를 선언했으나 `Tests/`가 비어(`.gitkeep`만) 있어 빈 xctest 번들이 "실행 파일 없음"으로 로드 실패했다 → #210에서 `.tests`를 제거해 CI에서 뺐다. 즉 지금 SettingFeature는 **테스트 0개**.
+- **왜 지금 안 했나**: VM 테스트 작성은 별건(지도 이슈 #205 축 B-B2 "Feature VM TDD"). 여러 `SettingViewModel`의 계약을 파악해 써야 해서 #210(기존 실패 청소) 범위 밖.
+- **어디를 고치나(할 때)**: `Projects/Feature/SettingFeature/Tests/`에 VM 테스트 추가 + `Project.swift` targets에 `.tests` 재선언(필요 시 `testDependencies`도). `NovelReviewFeature`가 선례.


### PR DESCRIPTION
## 💡 Issue

- closed #210

## 💭 Summary

A1이 자동 CI를 켜자 드러난 **기존 테스트 실패 4개**를 정리해 develop을 초록으로 만든다. 이로써 `All Tests Passed`를 필수 통과 체크로 켤 수 있게 된다(A1의 마지막 조각). 이슈 #205 로드맵 축 A.

## 🔑 Key Changes

전부 **기존 결함**(A1 자동 CI가 드러냄, 이번에 새로 생긴 게 아님):

- **AuthDomain**: `SyncAppleCredentialUseCaseTests`에 `import BaseDomain` 추가 — `RepositoryError`를 명시적으로 쓰는데 import가 빠져 컴파일 실패(형제 테스트엔 다 있음). → 18 테스트 통과.
- **ProfileDomain**: `StubKeywordRepository`에 `fetchPopularKeywords` 추가 — 프로토콜에 메서드가 추가됐는데 테스트 stub이 안 따라와 conformance 실패(drift). → 74 테스트 통과.
- **ProfileData**: `loadInitialProfile` 테스트의 장르 문자열 `"ROMANCE"`→`"romance"` — 매퍼(`ProfileMapper.novelGenre`)는 서버 스펙 camelCase를 받는데 대문자를 넣어 `MappingError`→`.invalidData`. 매퍼가 정본이라 테스트 데이터를 정합화. → 19 테스트 통과.
- **SettingFeature**: 빈 `.tests` 타깃 제거 — `Tests/`가 `.gitkeep`뿐(테스트 0개)이라 빈 xctest 번들이 "실행 파일 없음"으로 로드 실패(exit 65). 실제 상태에 맞춰 제거(`FeedFeature`와 동일 패턴), discover 스캔 30→29. → 빌드 성공.
- **docs**: TODO의 모듈 수 하드코딩 제거 + SettingFeature 테스트 재선언 항목(9번) 추가.

로컬 검증 전부 통과 + arch-lint 0/0.

## 📱 Simulation

해당 없음 (테스트/설정 정리).

## 🧑‍🧒‍🧒 To Reviewer

- 4개 모두 **소스 로직이 아니라 테스트/stub/설정**의 정합화다(ProfileData도 매퍼가 아니라 테스트 데이터를 고침).
- **SettingFeature는 이제 테스트 0개** — VM 테스트 작성은 로드맵 B2로 미룸(TODO 9번에 기록). 나중에 쓰면 `.tests` 재선언.
- **머지 후**: develop 초록 확인 → `All Tests Passed`를 required status check로 켜면 A1의 테스트 게이트가 실전 가동(A2의 `Architecture Rules` 옆에서 두 번째 게이트).

## ※ Reference

- 로드맵(지도 이슈): #205 / A1: #208
