### PR TITLE
[Feat] #191 - CollectionDomain·CollectionData 모듈 생성 (컬렉션 CRUD·좋아요)

### DIFF
--- a/.claude/skills/api-spec/SKILL.md
+++ b/.claude/skills/api-spec/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: api-spec
+description: WSS-iOS-V2에서 서버 API 스펙(OpenAPI/Swagger)이 필요할 때 사용한다. Data 레이어 DTO·Endpoint를 짜기 전, Domain Entity 필드셋을 확정하기 전, 또는 응답 필드·에러 코드를 확인할 때 dev 서버 OpenAPI 명세를 받아 읽는다. "API 스펙 확인해줘", "스웨거 봐줘", "이 엔드포인트 응답이 뭐야", "/api-spec <키워드>" 같은 요청에 트리거.
+metadata:
+  short-description: 서버 OpenAPI 명세 조회 (Swagger UI 링크 대신 JSON 직접 열람)
+---
+
+# API Spec — 서버 OpenAPI 명세 조회 (WSS-iOS-V2)
+
+Swagger **UI 링크는 에이전트에게 쓸모없다**. UI는 빈 HTML 껍데기고 명세는 JS가 나중에 받아온다.
+아래 **JSON 원본**을 직접 받아 읽는다.
+
+## 스펙 위치 (중요)
+
+| URL | 인증 | 비고 |
+|---|---|---|
+| `https://dev.websoso.kr/swagger-ui/openapi3.json` | **불필요** ✅ | **이걸 쓴다.** 정적 파일이라 그냥 열린다 |
+| `https://dev.websoso.kr/v3/api-docs` | 필요 ❌ | 인증 필터에 막혀 401 (`AUTH-001`). 함정 |
+| `https://dev.websoso.kr/swagger-ui/index.html` | - | 사람용 UI. 에이전트가 fetch하면 내용 없음 |
+
+> Swagger UI 상단 Explore 입력창의 값(`./openapi3.json`)이 실제 스펙 경로다.
+> 서버가 경로를 바꾸면 UI를 브라우저로 열어 그 값을 다시 확인한다.
+
+## 절차
+
+### 1. 조회
+
+```bash
+# 전체 엔드포인트 한 줄 목록
+node .claude/skills/api-spec/scripts/fetch-api-spec.mjs
+
+# 키워드(경로·태그·summary) 매칭 → 요청/응답 스키마 + 에러 코드 예시까지
+node .claude/skills/api-spec/scripts/fetch-api-spec.mjs collection
+
+# 원본 JSON이 필요하면 (스크래치패드에 저장해 재사용)
+node .claude/skills/api-spec/scripts/fetch-api-spec.mjs --json > <스크래치패드>/openapi3.json
+```
+
+node가 PATH에 없으면 `/opt/homebrew/bin/node`를 쓴다. node 자체가 없을 때의 무의존 대안:
+
+```bash
+curl -s https://dev.websoso.kr/swagger-ui/openapi3.json | python3 -m json.tool | less
+```
+
+운영 서버 등 다른 스펙을 볼 땐 `WSS_SPEC_URL=<url>`로 덮어쓴다.
+
+### 2. 찾는 API가 없을 때 (자주 겪는다)
+
+이 명세는 **Spring REST Docs 테스트로 생성**된다 → 서버에 문서화 테스트가 있는 엔드포인트만 올라온다.
+앱이 실제로 쓰는 API의 극히 일부만 담겨 있다(스크립트가 매번 총 개수와 태그 분포를 함께 출력하니 그 숫자로 감을 잡는다).
+
+**"스펙에 없다 ≠ 서버에 없다"** — 순서대로 확인한다:
+
+1. 전체 목록을 눈으로 훑는다. **제품 용어와 서버 용어가 다르다** — 예를 들어 "서재"는 경로에 `library`가 없고
+   `/users/{userId}/novels` 다. 감이 안 오면 `Projects/Data/*/Sources/Endpoint/`의 `path`를 먼저 보고 키워드를 정한다.
+2. 그래도 없으면 **기존 Data 모듈의 코드가 그 API의 진실 소스**다 —
+   `Projects/Data/<모듈>Data/Sources/Endpoint/` 와 `Sources/DTO/` 를 읽는다.
+3. 신규 API인데 스펙에도 코드에도 없으면 서버팀에 문서화를 요청한다. 추측으로 DTO를 짜지 않는다.
+
+### 3. 읽을 때 확인할 것
+
+- **엔드포인트 description(`>` 인용 블록)을 건너뛰고 스키마부터 보지 말 것.** summary 한 줄에 없는 운영 규칙이
+  거기 있다 — "마이페이지 미리보기는 이 API를 size=3으로 호출해 구성한다" 처럼 **화면 구성 방식**을 정해버리는 문장,
+  커서 페이지네이션 절차, 필드 간 관계, 에러 코드별 의미까지.
+- **필드 description에 정책이 들어있다** — 글자 수 제한, null 조건, 정렬 순서, "이번 페이지 개수가 아니다" 같은 함정.
+  Entity·DTO 주석과 Domain 테스트 케이스는 여기서 그대로 따온다.
+  - **배열·중첩 객체 필드의 description을 특히 흘리지 말 것.** 설계를 좌우하는 정책이 거기 몰려 있다
+    (예: `novelIds` → "배열 순서가 그대로 표시 순서로 저장되며 앞쪽이 최신", `recentNovels` → "최대 5개이고 대표 작품을 제외하지 않는다").
+- **`*` 표시가 required 필드다.** 스크립트가 스키마의 `required` 배열을 반영해 붙인다 —
+  다만 응답 쪽은 비어 있을 수 있으니, optional 판단은 `*` 유무와 description의 "생략할 수 있고" / "없으면 null이다" 문구를 **함께** 본다.
+- **요청 바디 content-type이 `application/json;charset=UTF-8`** 이다. `application/json`만 정확 매칭하면
+  requestBody가 통째로 누락된다(스크립트는 prefix 매칭으로 처리 완료).
+- **에러 코드는 `responses[*].examples`에 있다.** 상태 코드만으론 원인 구분이 안 되므로
+  (`400`에 `BAD_REQUEST`/`COLLECTION-002`/`COLLECTION-003`… 공존) `RepositoryError` 매핑은 **code 문자열 기준**으로 짠다.
+  - 공용 매핑은 `Projects/Data/BaseData/Sources/Networking/NetworkingError+RepositoryError.swift`의 `toRepositoryError()`.
+    특정 화면에서만 의미가 다른 코드(예: 비공개·차단)는 공용 매핑에 섞지 말고 **그 Data 리포지토리 메서드에서** 개별 변환한다
+    (`RepositoryError.privateProfile` 선례 — `BaseDomain/CLAUDE.md` 참고).
+
+### 4. 인증이 필요한 API를 실제로 호출해봐야 할 때
+
+`Config/Config_Debug.xcconfig`의 `TEST_API_KEY`는 **만료돼 있을 수 있다**(`AUTH-000`).
+개발용 토큰 발급 엔드포인트로 새로 받는다:
+
+```bash
+curl -s -X POST https://dev.websoso.kr/users/login \
+  -H 'Content-Type: application/json' -d '42'          # 본문은 DB에 있는 사용자 ID 숫자만
+# → {"Authorization":"<Access Token>"}
+```
+
+Access Token만 나오고 Refresh Token은 안 나온다. 클라이언트 로직에 쓰면 안 된다(deprecated 표시된 보조 API).
+
+## 주의사항 (작업 중 발견 시 누적)
+
+- 사용자가 Swagger **UI 링크**를 주면 그대로 fetch하지 말고 위 `openapi3.json`으로 바꿔 접근한다. UI 링크만 보고
+  "인증이 막혀 못 본다"고 결론 내린 적이 있다 — 실제로는 인증 없이 열리는 경로가 따로 있었다.
+- 스크립트 경로는 **`.claude/skills/...`** 로 쓴다. 이 머신엔 `.agents/skills → ../.claude/skills` 심링크가 있어
+  `.agents/...` 로도 실행되지만, 그 링크는 `.git/info/exclude`에 등록된 **로컬 전용**이라 팀원이 clone하면 없다.

--- a/.claude/skills/api-spec/scripts/fetch-api-spec.mjs
+++ b/.claude/skills/api-spec/scripts/fetch-api-spec.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// 웹소소 서버 OpenAPI 명세를 받아 사람이 읽는 마크다운으로 출력한다.
+//
+// 사용:
+//   node fetch-api-spec.mjs                 → 전체 엔드포인트 한 줄 목록
+//   node fetch-api-spec.mjs collection      → 키워드(경로/태그/summary) 매칭 엔드포인트 상세
+//   node fetch-api-spec.mjs --json          → 원본 OpenAPI JSON 그대로
+//
+// 스펙 URL은 WSS_SPEC_URL 환경변수로 덮어쓸 수 있다(운영 서버 등).
+const SPEC_URL = process.env.WSS_SPEC_URL || 'https://dev.websoso.kr/swagger-ui/openapi3.json';
+
+const args = process.argv.slice(2);
+const wantJson = args.includes('--json');
+const keyword = args.find((a) => !a.startsWith('--'));
+
+const res = await fetch(SPEC_URL);
+if (!res.ok) {
+  console.error('스펙을 받지 못했습니다: ' + res.status + ' ' + SPEC_URL);
+  process.exit(1);
+}
+const spec = await res.json();
+
+if (wantJson) {
+  console.log(JSON.stringify(spec, null, 2));
+  process.exit(0);
+}
+
+// 이 명세는 서버의 Spring REST Docs 테스트로 생성된다 → 문서화 테스트가 있는 엔드포인트만 올라온다.
+// 전체 개수를 늘 함께 보여줘야 "찾는 API가 없다 = 서버에 없다"는 오해를 막을 수 있다.
+const endpoints = [];
+const tagCount = {};
+for (const [p, ops] of Object.entries(spec.paths)) {
+  for (const [m, o] of Object.entries(ops)) {
+    endpoints.push({ path: p, method: m, op: o });
+    for (const t of o.tags || []) tagCount[t] = (tagCount[t] || 0) + 1;
+  }
+}
+const tagSummary = Object.entries(tagCount)
+  .map(([t, n]) => t + '(' + n + ')')
+  .join(', ');
+
+const coverageNote =
+  '이 명세는 서버의 Spring REST Docs 테스트로 생성되어 **문서화된 엔드포인트만** 담긴다 (현재 총 ' +
+  endpoints.length +
+  '개: ' +
+  tagSummary +
+  ').\n여기 없다고 "서버에 없는 API"는 아니다 — 아직 문서화되지 않았을 뿐일 수 있으니 서버팀에 확인한다.';
+
+if (!keyword) {
+  console.log('# ' + (spec.info?.title || 'API') + ' — 엔드포인트 목록');
+  console.log('출처: ' + SPEC_URL + '\n');
+  console.log(coverageNote + '\n');
+  for (const { path: p, method: m, op: o } of endpoints) {
+    const tags = (o.tags || []).join(',');
+    console.log('- ' + m.toUpperCase().padEnd(6) + p + '  — ' + (o.summary || '') + (tags ? '  [' + tags + ']' : ''));
+  }
+  process.exit(0);
+}
+
+const kw = keyword.toLowerCase();
+const matches = (p, ops) =>
+  p.toLowerCase().includes(kw) ||
+  Object.values(ops).some((o) =>
+    (o.tags || []).concat(o.summary || '').join(' ').toLowerCase().includes(kw),
+  );
+
+const deref = (o, seen = new Set()) => {
+  if (!o || typeof o !== 'object') return o;
+  if (o.$ref) {
+    if (seen.has(o.$ref)) return { circular: o.$ref };
+    let cur = spec;
+    for (const k of o.$ref.replace(/^#\//, '').split('/')) cur = cur?.[k];
+    return deref(cur, new Set([...seen, o.$ref]));
+  }
+  if (Array.isArray(o)) return o.map((x) => deref(x, seen));
+  return Object.fromEntries(Object.entries(o).map(([k, v]) => [k, deref(v, seen)]));
+};
+
+// 필드 description에는 글자 수 제한·null 조건·정렬 순서 같은 정책이 들어 있고, Entity/DTO 주석과
+// Domain 테스트 케이스가 여기서 나온다. 배열·중첩 객체 필드도 예외가 아니다
+// (예: novelIds의 "배열 순서가 그대로 표시 순서로 저장된다") → 어느 분기에서도 description을 떨어뜨리지 않는다.
+const shape = (s, ind = '') => {
+  s = deref(s);
+  if (!s) return ind + '?';
+
+  const required = new Set(s.required || []);
+  const line = (k, body, desc) =>
+    ind + k + (required.has(k) ? '*' : '') + ': ' + body + (desc ? '  // ' + desc : '');
+
+  if (s.properties) {
+    return Object.entries(s.properties)
+      .map(([k, v]) => {
+        const t = deref(v);
+        const desc = t.description || '';
+        if (t.type === 'array') {
+          const items = deref(t.items);
+          if (items?.properties) {
+            return line(k, '[{', desc) + '\n' + shape(items, ind + '  ') + '\n' + ind + '}]';
+          }
+          return line(k, '[' + (items?.type || '?') + ']', desc);
+        }
+        if (t.properties) {
+          return line(k, '{', desc) + '\n' + shape(t, ind + '  ') + '\n' + ind + '}';
+        }
+        return line(k, t.type || '?', desc);
+      })
+      .join('\n');
+  }
+
+  if (s.type === 'array') {
+    const items = deref(s.items);
+    if (items?.properties) return ind + '[{\n' + shape(items, ind + '  ') + '\n' + ind + '}]';
+    return ind + '[' + (items?.type || '?') + ']';
+  }
+  return ind + (s.type || '?');
+};
+
+// 서버가 requestBody를 application/json;charset=UTF-8 로 주는 경우가 있어 prefix 매칭이 필요하다.
+// 'application/json'만 정확히 찾으면 요청 바디가 통째로 누락된다.
+const jsonContent = (c) => {
+  if (!c) return null;
+  const k = Object.keys(c).find((x) => x.startsWith('application/json'));
+  return k ? c[k] : null;
+};
+
+// examples의 value는 보통 JSON 문자열이지만 객체로 오는 경우도 있다 → [object Object] 방지.
+const fmtExample = (v) => (typeof v === 'string' ? v : JSON.stringify(v));
+
+const hits = Object.entries(spec.paths).filter(([p, ops]) => matches(p, ops));
+
+if (hits.length === 0) {
+  console.log('# "' + keyword + '" 와(과) 일치하는 엔드포인트가 없습니다.\n');
+  console.log('출처: ' + SPEC_URL + '\n');
+  console.log(coverageNote + '\n');
+  console.log('다음으로 할 일:');
+  console.log('1. 전체 목록을 눈으로 확인한다 (키워드가 서버 용어와 다를 수 있다)');
+  console.log('   node .claude/skills/api-spec/scripts/fetch-api-spec.mjs');
+  console.log('2. 그래도 없으면 기존 Data 모듈의 Endpoint/DTO 코드가 그 API의 진실 소스다');
+  console.log('   ls Projects/Data/*/Sources/Endpoint/');
+  process.exit(0);
+}
+
+const out = [];
+out.push('# ' + (spec.info?.title || 'API') + ' — "' + keyword + '" 관련 엔드포인트');
+out.push('\n출처: ' + SPEC_URL);
+out.push('스키마의 `*` 표시는 required 필드다.\n');
+
+for (const [p, ops] of hits) {
+  for (const [m, o] of Object.entries(ops)) {
+    out.push('\n---\n\n## ' + m.toUpperCase() + ' ' + p + ' — ' + (o.summary || '') + '\n');
+    if (o.deprecated) out.push('> deprecated\n');
+
+    // operation의 description에는 summary에 없는 운영 규칙이 들어 있다 —
+    // "마이페이지 미리보기는 이 API를 size=3으로 호출해 구성한다", 커서 페이지네이션 절차,
+    // 필드 간 관계(대표 작품이 recentNovels에 함께 내려간다) 같은, 화면 설계를 좌우하는 내용이다.
+    if (o.description) {
+      out.push(o.description.trim().split('\n').map((l) => '> ' + l).join('\n') + '\n');
+    }
+
+    if (o.parameters?.length) {
+      out.push('**Parameters**\n');
+      for (const x of o.parameters) {
+        out.push('- ' + x.name + ' (' + x.in + (x.required ? ', required' : '') + ') — ' + (x.description || ''));
+      }
+      out.push('');
+    }
+
+    const rb = jsonContent(o.requestBody?.content);
+    if (rb) {
+      out.push('**Request**\n');
+      out.push('```');
+      out.push(shape(rb.schema));
+      out.push('```');
+      const ex = Object.values(rb.examples || {})[0]?.value;
+      if (ex) out.push('예시: ' + fmtExample(ex) + '\n');
+    }
+
+    for (const [code, r] of Object.entries(o.responses || {})) {
+      const c = jsonContent(r.content);
+      if (!c) {
+        out.push('**Response ' + code + '** — 본문 없음\n');
+        continue;
+      }
+      out.push('**Response ' + code + '**\n');
+      if (code.startsWith('2')) {
+        out.push('```');
+        out.push(shape(c.schema));
+        out.push('```');
+      }
+      const exs = Object.values(c.examples || {});
+      if (exs.length) out.push(exs.map((v) => '- ' + fmtExample(v.value)).join('\n') + '\n');
+    }
+  }
+}
+
+console.log(out.join('\n'));

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
@@ -48,6 +48,7 @@ public enum DomainModule: String, ModuleSpec {
     case profile
     case social
     case search
+    case collection
 }
 
 public enum DataModule: String, ModuleSpec {
@@ -65,6 +66,7 @@ public enum DataModule: String, ModuleSpec {
     case feed
     case novel
     case search
+    case collection
 }
 
 public enum CoreModule: String, ModuleSpec {

--- a/Projects/Core/Logger/Sources/OSLogger.swift
+++ b/Projects/Core/Logger/Sources/OSLogger.swift
@@ -47,6 +47,7 @@ public extension OSLogger {
     static let profile      = OSLogger(category: .profile)
     static let social       = OSLogger(category: .social)
     static let search       = OSLogger(category: .search)
+    static let collection   = OSLogger(category: .collection)
 }
 
 // MARK: - LogCategory
@@ -65,4 +66,5 @@ public enum LogCategory: String {
     case profile
     case social
     case search
+    case collection
 }

--- a/Projects/Data/CollectionData/CLAUDE.md
+++ b/Projects/Data/CollectionData/CLAUDE.md
@@ -22,3 +22,14 @@
   화면에서만 의미가 다른 코드는 공용 `NetworkingError.toRepositoryError()`에 섞지 말고 이 모듈의 리포지토리 메서드에서 변환한다
   (`RepositoryError.privateProfile` 선례 — `BaseDomain/CLAUDE.md`).
 - 커서는 **서버가 발급한 불투명 문자열**이다. 마지막 아이템 ID로 유도하거나 파싱하지 말고 받은 값을 그대로 되돌려 보낸다.
+- **Query DTO는 `Encodable`이 아니라 `QueryItemConvertible`(Networking)을 준수해야 한다.** `Encodable`만 붙이면
+  `.convertible(query)`에서 "does not conform" 컴파일 에러가 난다. 기본 구현이 nil 값을 쿼리에서 알아서 빼주므로
+  첫 페이지의 `cursor: nil`을 따로 분기할 필요가 없다.
+- **정렬 파라미터는 대소문자가 다르다.** 서버는 `RECENT`/`OLD`를 받는데 `BaseDomain.SortType`의 rawValue는 소문자다
+  → `CollectionDetailQuery`가 `uppercased()`로 맞춘다. 도메인 enum을 서버 표기에 맞추려 고치지 말 것(다른 도메인도 쓴다).
+- **목록 API 하나가 Repository 메서드 셋을 떠받친다.** 미리보기·컬렉션 목록이 같은 `getUserCollections`를 호출하고
+  Mapper만 갈린다(`collectionPreviews` / `collectionCards`). 엔드포인트를 추가하기 전에 Mapper로 해결되는지 먼저 볼 것.
+- **Demo 앱은 `TEST_API_KEY`(`Config_Debug.xcconfig`)로 인증한다.** 만료되면 모든 호출이 `AUTH-000`으로 실패한다 —
+  Demo가 안 될 때 코드부터 의심하지 말고 토큰부터 확인할 것. 갱신 방법은 `/api-spec` 스킬 문서에 있다.
+- 컬렉션 상세만 `usesTokenIfAvailable`이다(공유 링크로 들어온 비로그인 조회자에게도 내려간다). 나머지는 `requireToken` —
+  목록 API의 비로그인 허용 여부는 서버 명세에 명시가 없어 보수적으로 잡아뒀다. 비로그인 진입 경로가 생기면 그때 확인해 바꾼다.

--- a/Projects/Data/CollectionData/CLAUDE.md
+++ b/Projects/Data/CollectionData/CLAUDE.md
@@ -1,0 +1,24 @@
+<!-- 모듈 가이드. 이 모듈 작업 시 상위 Projects/Data/CLAUDE.md(레이어 규칙)와 함께 자동 로드됨. -->
+# CollectionData
+
+`CollectionDomain` 계약의 서버 구현. 구성요소는 `Sources/`를 직접 보면 된다.
+
+- 식별자: `ModuleType.data(.collection)` / 진입점: `CollectionDataFactory`
+- 서버 명세: `/api-spec collection`
+
+## 핵심 시나리오
+
+- **하나의 목록 응답 DTO에서 두 Entity가 나온다.** 마이페이지용 `CollectionPreview`와 리스트용 `CollectionCard`는
+  같은 엔드포인트·같은 DTO를 쓰고 **Mapper만 갈린다**. 화면이 늘어도 Endpoint·Service를 복제하지 말 것.
+  (왜 나눴는지는 `CollectionDomain/CLAUDE.md` 참고.)
+
+## 주의사항 (작업 중 발견 시 누적)
+
+- **`isPublic` → `isPrivate` 뒤집기는 여기(Mapper)에서만 한다.** 도메인·화면은 이미 "나만 보는" 방향으로 통일돼 있으니
+  어디서도 다시 뒤집지 말 것.
+- **에러는 상태 코드가 아니라 `code` 문자열로 분기한다.** `400` 하나에 `BAD_REQUEST`·`COLLECTION-002`(작품 1~100개)·
+  `COLLECTION-003`(중복 작품)·`COLLECTION-004`(대표 작품이 목록에 없음)·`COLLECTION-007`(잘못된 커서)·
+  `COLLECTION-008`(size 범위)이 공존한다. `401`도 `AUTH-000`/`AUTH-001`/`AUTH-003`으로 갈린다.
+  화면에서만 의미가 다른 코드는 공용 `NetworkingError.toRepositoryError()`에 섞지 말고 이 모듈의 리포지토리 메서드에서 변환한다
+  (`RepositoryError.privateProfile` 선례 — `BaseDomain/CLAUDE.md`).
+- 커서는 **서버가 발급한 불투명 문자열**이다. 마지막 아이템 ID로 유도하거나 파싱하지 말고 받은 값을 그대로 되돌려 보낸다.

--- a/Projects/Data/CollectionData/CLAUDE.md
+++ b/Projects/Data/CollectionData/CLAUDE.md
@@ -16,10 +16,12 @@
 
 - **`isPublic` → `isPrivate` 뒤집기는 여기(Mapper)에서만 한다.** 도메인·화면은 이미 "나만 보는" 방향으로 통일돼 있으니
   어디서도 다시 뒤집지 말 것.
-- **에러는 상태 코드가 아니라 `code` 문자열로 분기한다.** `400` 하나에 `BAD_REQUEST`·`COLLECTION-002`(작품 1~100개)·
-  `COLLECTION-003`(중복 작품)·`COLLECTION-004`(대표 작품이 목록에 없음)·`COLLECTION-007`(잘못된 커서)·
-  `COLLECTION-008`(size 범위)이 공존한다. `401`도 `AUTH-000`/`AUTH-001`/`AUTH-003`으로 갈린다.
-  화면에서만 의미가 다른 코드는 공용 `NetworkingError.toRepositoryError()`에 섞지 말고 이 모듈의 리포지토리 메서드에서 변환한다
+- **에러는 상태 코드가 아니라 `code` 문자열로 분기할 여지가 크다(현재는 미구현 — 소비 화면 연결 시 도입 예정).**
+  `400` 하나에 `BAD_REQUEST`·`COLLECTION-002`(작품 1~100개)·`COLLECTION-003`(중복 작품)·
+  `COLLECTION-004`(대표 작품이 목록에 없음)·`COLLECTION-007`(잘못된 커서)·`COLLECTION-008`(size 범위)이 공존하고,
+  `401`도 `AUTH-000`/`AUTH-001`/`AUTH-003`으로 갈린다. 지금 `DefaultCollectionRepository`는 공용
+  `NetworkingError.toRepositoryError()`만 쓴다 — Feature가 아직 없어 코드별 구분을 미뤄뒀다.
+  화면에서만 의미가 다른 코드가 필요해지면 공용 변환에 섞지 말고 이 모듈의 리포지토리 메서드에서 변환할 것
   (`RepositoryError.privateProfile` 선례 — `BaseDomain/CLAUDE.md`).
 - 커서는 **서버가 발급한 불투명 문자열**이다. 마지막 아이템 ID로 유도하거나 파싱하지 말고 받은 값을 그대로 되돌려 보낸다.
 - **Query DTO는 `Encodable`이 아니라 `QueryItemConvertible`(Networking)을 준수해야 한다.** `Encodable`만 붙이면

--- a/Projects/Data/CollectionData/Demo/CollectionDataDemoApp.swift
+++ b/Projects/Data/CollectionData/Demo/CollectionDataDemoApp.swift
@@ -1,0 +1,19 @@
+//
+//  CollectionDataDemoApp.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import SwiftUI
+import CollectionData
+
+@main
+struct CollectionDataDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            CollectionDataDemoView()
+        }
+    }
+}

--- a/Projects/Data/CollectionData/Demo/CollectionDataDemoView.swift
+++ b/Projects/Data/CollectionData/Demo/CollectionDataDemoView.swift
@@ -1,0 +1,184 @@
+//
+//  CollectionDataDemoView.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import SwiftUI
+
+import CollectionData
+import CollectionDomain
+import BaseDomain
+import Networking
+import BaseData
+import Logger
+
+struct CollectionDataDemoView: View {
+
+    @State private var log: String = "버튼을 눌러 API를 호출하세요."
+    @State private var isLoading: Bool = false
+    @State private var userIDText: String = "1"
+    @State private var collectionIDText: String = ""
+
+    /// 다음 페이지 호출에 쓸 서버 발급 커서. 페이지네이션이 실제로 이어지는지 Demo에서 확인하려면 들고 있어야 한다.
+    @State private var nextCursor: String?
+
+    private let repository: any CollectionRepository
+
+    init() {
+        let client = NetworkingClient(tokenStore: DemoSessionTokenStore())
+        let logger = DataLogger(moduleName: "CollectionData", underlying: OSLogger.collection)
+        self.repository = CollectionDataFactory.makeRepository(network: client, logger: logger)
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 12) {
+                inputFields
+                listButtons
+                detailButtons
+
+                ScrollView {
+                    Text(log)
+                        .font(.system(size: 13, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                }
+                .background(Color(.systemGray6))
+                .cornerRadius(8)
+                .padding(.horizontal)
+            }
+            .padding(.vertical)
+            .navigationTitle("Collection Demo")
+            .overlay { if isLoading { ProgressView() } }
+        }
+    }
+
+    private var inputFields: some View {
+        HStack {
+            TextField("userID", text: $userIDText)
+                .textFieldStyle(.roundedBorder)
+                .keyboardType(.numberPad)
+
+            TextField("collectionID", text: $collectionIDText)
+                .textFieldStyle(.roundedBorder)
+                .keyboardType(.numberPad)
+        }
+        .padding(.horizontal)
+    }
+
+    private var listButtons: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Button("미리보기(size=3)") { Task { await fetchPreviews() } }
+                Button("목록 첫 페이지") { Task { await fetchCollections(useCursor: false) } }
+                Button("다음 페이지") { Task { await fetchCollections(useCursor: true) } }
+            }
+            Button("좋아요한 컬렉션") { Task { await fetchLikedCollections() } }
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private var detailButtons: some View {
+        HStack {
+            Button("상세(최신순)") { Task { await fetchDetail(sortType: .recent) } }
+            Button("상세(오래된순)") { Task { await fetchDetail(sortType: .old) } }
+            Button("좋아요") { Task { await toggleLike(isLike: true) } }
+            Button("좋아요 취소") { Task { await toggleLike(isLike: false) } }
+        }
+        .buttonStyle(.bordered)
+    }
+}
+
+// MARK: - API 호출
+
+private extension CollectionDataDemoView {
+
+    var userID: UserID { UserID(Int(userIDText) ?? 0) }
+    var collectionID: CollectionID { CollectionID(Int(collectionIDText) ?? 0) }
+
+    func fetchPreviews() async {
+        await run {
+            let (previews, totalCount) = try await repository.fetchCollectionPreviews(userID: userID, size: 3)
+            return """
+            미리보기 \(previews.count)개 / 전체 \(totalCount)개
+            \(previews.map { "· \($0.name) — 대표: \($0.representativeNovel.title)" }.joined(separator: "\n"))
+            """
+        }
+    }
+
+    func fetchCollections(useCursor: Bool) async {
+        await run {
+            let (page, totalCount) = try await repository.fetchCollections(
+                userID: userID,
+                cursor: useCursor ? nextCursor : nil,
+                size: 10
+            )
+            nextCursor = page.nextCursor
+
+            return """
+            카드 \(page.items.count)개 / 전체 \(totalCount)개 / hasNext \(page.hasNext)
+            nextCursor: \(page.nextCursor ?? "없음")
+            \(page.items.map(describe(card:)).joined(separator: "\n"))
+            """
+        }
+    }
+
+    func fetchLikedCollections() async {
+        await run {
+            let (page, totalCount) = try await repository.fetchLikedCollections(cursor: nil, size: 10)
+            return """
+            좋아요한 컬렉션 \(page.items.count)개 / 전체 \(totalCount)개
+            \(page.items.map(describe(card:)).joined(separator: "\n"))
+            """
+        }
+    }
+
+    func fetchDetail(sortType: SortType) async {
+        await run {
+            let detail = try await repository.fetchCollectionDetail(id: collectionID, sortType: sortType)
+            return """
+            \(detail.name) (\(detail.isPrivate ? "나만 보는" : "공개"))
+            소유자: \(detail.owner.nickname) / 내 컬렉션: \(detail.isMine)
+            좋아요 \(detail.likeCount) / 눌렀나: \(detail.isLiked)
+            작품 \(detail.novelCount)개, 정렬 \(sortType)
+            \(detail.novels.map { "· \($0.title) — \($0.author)" }.joined(separator: "\n"))
+            """
+        }
+    }
+
+    func toggleLike(isLike: Bool) async {
+        await run {
+            if isLike {
+                try await repository.likeCollection(id: collectionID)
+            } else {
+                try await repository.unlikeCollection(id: collectionID)
+            }
+            return "좋아요 \(isLike ? "등록" : "취소") 성공 (서버가 멱등이라 반복 호출도 성공한다)"
+        }
+    }
+
+    /// 카드에서 확인할 값들 — 대표 작품이 미리보기에 함께 오는지, novelCount가 미리보기 개수와 다른지가 핵심이다.
+    func describe(card: CollectionCard) -> String {
+        """
+        · \(card.name) [\(card.isPrivate ? "나만 보는" : "공개")]
+          전체 \(card.novelCount)개 / 미리보기 \(card.recentNovels.count)개
+          미리보기: \(card.recentNovels.map(\.title).joined(separator: ", "))
+        """
+    }
+
+    func run(_ operation: @escaping () async throws -> String) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            log = try await operation()
+        } catch let error as RepositoryError {
+            log = "❌ RepositoryError.\(error)"
+        } catch {
+            log = "❌ \(error)"
+        }
+    }
+}

--- a/Projects/Data/CollectionData/Project.swift
+++ b/Projects/Data/CollectionData/Project.swift
@@ -1,0 +1,22 @@
+//
+//  Project.swift
+//  AppManifests
+//
+//  Created by YunhakLee on 8/18/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.createDataModule(
+    name: ModuleType.data(.collection).name,
+    targets: [.sources, .demo],
+    internalDependencies: [
+        .module(.core(.networking)),
+        .module(.core(.logger)),
+        .module(.data(.base)),
+        .module(.domain(.base)),
+        .module(.domain(.collection))
+    ]
+)

--- a/Projects/Data/CollectionData/Sources/DTO/Query/CollectionDetailQuery.swift
+++ b/Projects/Data/CollectionData/Sources/DTO/Query/CollectionDetailQuery.swift
@@ -1,0 +1,21 @@
+//
+//  CollectionDetailQuery.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import Networking
+
+import BaseDomain
+
+public struct CollectionDetailQuery: QueryItemConvertible {
+    /// 서버는 `RECENT`/`OLD` 대문자를 받는다. 도메인 `SortType`의 rawValue는 소문자라 여기서 맞춘다.
+    public let sortCriteria: String
+
+    public init(sortType: SortType) {
+        self.sortCriteria = sortType.rawValue.uppercased()
+    }
+}

--- a/Projects/Data/CollectionData/Sources/DTO/Query/CollectionsQuery.swift
+++ b/Projects/Data/CollectionData/Sources/DTO/Query/CollectionsQuery.swift
@@ -1,0 +1,22 @@
+//
+//  CollectionsQuery.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+import Networking
+
+/// nil인 cursor는 `QueryItemConvertible` 기본 구현이 쿼리에서 알아서 제외한다.
+public struct CollectionsQuery: QueryItemConvertible {
+    /// 직전 응답의 `nextCursor`. 첫 페이지는 nil이며, 서버가 발급한 값을 그대로 되돌려 보낸다.
+    public let cursor: String?
+    public let size: Int
+
+    public init(cursor: String?, size: Int) {
+        self.cursor = cursor
+        self.size = size
+    }
+}

--- a/Projects/Data/CollectionData/Sources/DTO/Request/SubmitCollectionRequest.swift
+++ b/Projects/Data/CollectionData/Sources/DTO/Request/SubmitCollectionRequest.swift
@@ -1,0 +1,24 @@
+//
+//  SubmitCollectionRequest.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+/// 컬렉션 생성·수정이 공유하는 요청 바디.
+///
+/// 도메인은 "나만 보는"(`isPrivate`) 방향인데 서버는 `isPublic`을 받는다 → 뒤집기는 Mapper가 한 번만 한다.
+public struct SubmitCollectionRequest: Encodable {
+    public let name: String
+    public let description: String?
+    public let isPublic: Bool
+
+    /// **배열 순서가 그대로 표시 순서로 저장된다**(앞쪽이 최신). 서버가 재정렬하지 않는다.
+    public let novelIds: [Int]
+
+    /// `novelIds`에 포함된 작품이어야 한다(아니면 `COLLECTION-004`).
+    public let representativeNovelId: Int
+}

--- a/Projects/Data/CollectionData/Sources/DTO/Response/CollectionDetailResponse.swift
+++ b/Projects/Data/CollectionData/Sources/DTO/Response/CollectionDetailResponse.swift
@@ -1,0 +1,38 @@
+//
+//  CollectionDetailResponse.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct CollectionDetailResponse: Decodable {
+    public let collectionId: Int
+    public let collectionName: String
+    public let collectionDescription: String?
+    public let isPublic: Bool
+
+    /// 조회자가 소유자인지 여부. 비로그인 조회는 항상 false다.
+    public let isMyCollection: Bool
+
+    public let owner: CollectionOwnerResponse
+    public let representativeNovelId: Int
+    public let novelCount: Int
+    public let likeCount: Int
+
+    /// 조회자가 좋아요를 눌렀는지 여부. 비로그인 조회는 항상 false다.
+    public let isLiked: Bool
+
+    /// 포함 작품 전체. 요청한 정렬 기준으로 정렬돼 오고 페이지네이션이 없다.
+    public let novels: [CollectionNovelResponse]
+}
+
+public struct CollectionOwnerResponse: Decodable {
+    public let userId: Int
+    public let nickname: String
+
+    /// 아바타는 모든 사용자가 반드시 가지므로 항상 내려온다.
+    public let avatarImage: String?
+}

--- a/Projects/Data/CollectionData/Sources/DTO/Response/CollectionNovelResponse.swift
+++ b/Projects/Data/CollectionData/Sources/DTO/Response/CollectionNovelResponse.swift
@@ -1,0 +1,17 @@
+//
+//  CollectionNovelResponse.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+/// 컬렉션 응답 전반(카드 미리보기·상세 목록)이 공유하는 작품 요약 구조.
+public struct CollectionNovelResponse: Decodable {
+    public let novelId: Int
+    public let title: String
+    public let novelImage: String?
+    public let author: String
+}

--- a/Projects/Data/CollectionData/Sources/DTO/Response/CollectionsResponse.swift
+++ b/Projects/Data/CollectionData/Sources/DTO/Response/CollectionsResponse.swift
@@ -1,0 +1,40 @@
+//
+//  CollectionsResponse.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+/// 컬렉션 목록(사용자별·좋아요한) 공통 응답.
+///
+/// 두 API의 카드 구조는 `likeCount` 하나만 다르다(좋아요한 목록에만 온다) → optional로 두고 한 DTO로 받는다.
+public struct CollectionsResponse: Decodable {
+    public let collections: [CollectionCardResponse]
+    public let hasNext: Bool
+    public let nextCursor: String?
+
+    /// 조회자가 볼 수 있는 **전체** 컬렉션 수. 이번 페이지 개수가 아니다.
+    public let collectionsCount: Int
+}
+
+public struct CollectionCardResponse: Decodable {
+    public let collectionId: Int
+    public let collectionName: String
+    public let collectionDescription: String?
+    public let isPublic: Bool
+
+    /// 컬렉션에 든 전체 작품 수. `recentNovels`의 개수가 아니다.
+    public let novelCount: Int
+
+    /// 카드 표지로 쓰는 대표 작품. `recentNovels`와 독립적이라 둘에 같은 작품이 들어올 수 있다.
+    public let representativeNovel: CollectionNovelResponse
+
+    /// 저장된 표시 순서 앞에서부터 최대 5개.
+    public let recentNovels: [CollectionNovelResponse]
+
+    /// 좋아요한 컬렉션 목록에만 내려온다. 현재 화면이 쓰지 않아 매핑하지 않는다.
+    public let likeCount: Int?
+}

--- a/Projects/Data/CollectionData/Sources/DTO/Response/CreateCollectionResponse.swift
+++ b/Projects/Data/CollectionData/Sources/DTO/Response/CreateCollectionResponse.swift
@@ -1,0 +1,13 @@
+//
+//  CreateCollectionResponse.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public struct CreateCollectionResponse: Decodable {
+    public let collectionId: Int
+}

--- a/Projects/Data/CollectionData/Sources/Endpoint/CollectionEndpoint.swift
+++ b/Projects/Data/CollectionData/Sources/Endpoint/CollectionEndpoint.swift
@@ -1,0 +1,94 @@
+//
+//  CollectionEndpoint.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import Networking
+import BaseData
+
+enum CollectionEndpoint: Endpoint {
+    case postCollection(SubmitCollectionRequest)
+    case getCollectionDetail(collectionID: Int, CollectionDetailQuery)
+    case putCollection(collectionID: Int, SubmitCollectionRequest)
+    case deleteCollection(collectionID: Int)
+    case putCollectionLike(collectionID: Int)
+    case deleteCollectionLike(collectionID: Int)
+    case getUserCollections(userID: Int, CollectionsQuery)
+    case getLikedCollections(CollectionsQuery)
+
+    var baseURL: URL {
+        URL(string: NetworkingConfig.baseURL) ?? URL(string: "")!
+    }
+
+    var path: String {
+        switch self {
+        case .postCollection:
+            return "/collections"
+        case .getCollectionDetail(let collectionID, _),
+             .putCollection(let collectionID, _),
+             .deleteCollection(let collectionID):
+            return "/collections/\(collectionID)"
+        case .putCollectionLike(let collectionID),
+             .deleteCollectionLike(let collectionID):
+            return "/collections/\(collectionID)/likes"
+        case .getUserCollections(let userID, _):
+            return "/users/\(userID)/collections"
+        case .getLikedCollections:
+            return "/users/me/liked-collections"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .postCollection:
+            return .post
+        case .getCollectionDetail, .getUserCollections, .getLikedCollections:
+            return .get
+        case .putCollection, .putCollectionLike:
+            return .put
+        case .deleteCollection, .deleteCollectionLike:
+            return .delete
+        }
+    }
+
+    var query: QueryParameters {
+        switch self {
+        case .getCollectionDetail(_, let query):
+            return .convertible(query)
+        case .getUserCollections(_, let query):
+            return .convertible(query)
+        case .getLikedCollections(let query):
+            return .convertible(query)
+        default:
+            return .none
+        }
+    }
+
+    var body: RequestBody {
+        switch self {
+        case .postCollection(let request),
+             .putCollection(_, let request):
+            return .json(request)
+        default:
+            return .none
+        }
+    }
+
+    var authorization: AuthorizationPolicy {
+        switch self {
+        // 공유 링크로 들어온 비로그인 조회자에게도 내려간다(소유자 정보 포함).
+        // 토큰이 있으면 isMyCollection·isLiked가 채워지므로 있으면 붙인다.
+        case .getCollectionDetail:
+            return .usesTokenIfAvailable
+        default:
+            return .requireToken
+        }
+    }
+
+    var additionalHeaders: [String: String]? { nil }
+}

--- a/Projects/Data/CollectionData/Sources/Factory/CollectionDataFactory.swift
+++ b/Projects/Data/CollectionData/Sources/Factory/CollectionDataFactory.swift
@@ -1,0 +1,27 @@
+//
+//  CollectionDataFactory.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import Networking
+import CollectionDomain
+import BaseData
+
+/// 모듈의 유일한 public 진입점.
+public enum CollectionDataFactory {
+    public static func makeRepository(
+        network: NetworkingRequestable,
+        logger: DataLogger? = nil
+    ) -> any CollectionRepository {
+        let service = DefaultCollectionService(network: network)
+        return DefaultCollectionRepository(
+            service: service,
+            logger: logger
+        )
+    }
+}

--- a/Projects/Data/CollectionData/Sources/Logger/CollectionAction.swift
+++ b/Projects/Data/CollectionData/Sources/Logger/CollectionAction.swift
@@ -1,0 +1,37 @@
+//
+//  CollectionAction.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import Logger
+
+public enum CollectionAction {
+    case fetchCollectionPreviews(userID: Int)
+    case fetchCollections(userID: Int)
+    case fetchLikedCollections
+    case fetchCollectionDetail(collectionID: Int)
+    case createCollection
+    case updateCollection(collectionID: Int)
+    case deleteCollection(collectionID: Int)
+    case likeCollection(collectionID: Int)
+    case unlikeCollection(collectionID: Int)
+
+    var name: String {
+        switch self {
+        case .fetchCollectionPreviews(let userID):      "마이페이지 컬렉션 미리보기 조회: \(userID)"
+        case .fetchCollections(let userID):             "컬렉션 목록 조회: \(userID)"
+        case .fetchLikedCollections:                    "좋아요한 컬렉션 목록 조회"
+        case .fetchCollectionDetail(let collectionID):  "컬렉션 상세 조회: \(collectionID)"
+        case .createCollection:                         "컬렉션 생성"
+        case .updateCollection(let collectionID):       "컬렉션 수정: \(collectionID)"
+        case .deleteCollection(let collectionID):       "컬렉션 삭제: \(collectionID)"
+        case .likeCollection(let collectionID):         "컬렉션 좋아요 등록: \(collectionID)"
+        case .unlikeCollection(let collectionID):       "컬렉션 좋아요 취소: \(collectionID)"
+        }
+    }
+}

--- a/Projects/Data/CollectionData/Sources/Mapper/CollectionMapper.swift
+++ b/Projects/Data/CollectionData/Sources/Mapper/CollectionMapper.swift
@@ -62,7 +62,7 @@ public enum CollectionMapper {
             owner: Author(
                 userId: UserID(dto.owner.userId),
                 nickname: dto.owner.nickname,
-                profileImage: dto.owner.avatarImage.flatMap(URL.init(string:))
+                profileImage: dto.owner.avatarImage.flatMap { ImageURLResolver.resolve(from: $0) }
             ),
             isMine: dto.isMyCollection,
             isPrivate: dto.isPublic == false,
@@ -102,7 +102,7 @@ public enum CollectionMapper {
             id: NovelID(dto.novelId),
             title: dto.title,
             author: dto.author,
-            thumbnailImage: dto.novelImage.flatMap(URL.init(string:))
+            thumbnailImage: dto.novelImage.flatMap { ImageURLResolver.resolve(from: $0) }
         )
     }
 }

--- a/Projects/Data/CollectionData/Sources/Mapper/CollectionMapper.swift
+++ b/Projects/Data/CollectionData/Sources/Mapper/CollectionMapper.swift
@@ -1,0 +1,108 @@
+//
+//  CollectionMapper.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseData
+import BaseDomain
+import CollectionDomain
+
+public enum CollectionMapper {
+
+    // MARK: - 목록
+
+    /// 마이페이지 섹션용. 같은 응답에서 대표 작품만 뽑아 쓴다.
+    /// - Returns: (미리보기 목록, 전체 컬렉션 수)
+    public static func collectionPreviews(from dto: CollectionsResponse) -> ([CollectionPreview], Int) {
+        let previews = dto.collections.map {
+            CollectionPreview(
+                id: CollectionID($0.collectionId),
+                name: $0.collectionName,
+                representativeNovel: collectionNovel(from: $0.representativeNovel)
+            )
+        }
+        return (previews, dto.collectionsCount)
+    }
+
+    /// 컬렉션 리스트·좋아요한 목록용. 같은 응답에서 미리보기 썸네일 줄을 쓴다.
+    /// - Returns: (커서 페이지, 전체 컬렉션 수)
+    public static func collectionCards(from dto: CollectionsResponse) -> (CursorPaginated<CollectionCard>, Int) {
+        let page = CursorPaginated(
+            items: dto.collections.map(collectionCard(from:)),
+            hasNext: dto.hasNext,
+            nextCursor: dto.nextCursor
+        )
+        return (page, dto.collectionsCount)
+    }
+
+    private static func collectionCard(from dto: CollectionCardResponse) -> CollectionCard {
+        CollectionCard(
+            id: CollectionID(dto.collectionId),
+            name: dto.collectionName,
+            description: dto.collectionDescription,
+            novelCount: dto.novelCount,
+            // 서버는 "공개인가"를, 도메인·화면은 "나만 보는가"를 말한다. 뒤집기는 여기 한 곳뿐이다.
+            isPrivate: dto.isPublic == false,
+            recentNovels: dto.recentNovels.map(collectionNovel(from:))
+        )
+    }
+
+    // MARK: - 상세
+
+    public static func collectionDetail(from dto: CollectionDetailResponse) -> CollectionDetail {
+        CollectionDetail(
+            id: CollectionID(dto.collectionId),
+            name: dto.collectionName,
+            description: dto.collectionDescription,
+            owner: Author(
+                userId: UserID(dto.owner.userId),
+                nickname: dto.owner.nickname,
+                profileImage: dto.owner.avatarImage.flatMap(URL.init(string:))
+            ),
+            isMine: dto.isMyCollection,
+            isPrivate: dto.isPublic == false,
+            representativeNovelID: NovelID(dto.representativeNovelId),
+            novels: dto.novels.map(collectionNovel(from:)),
+            likeCount: dto.likeCount,
+            isLiked: dto.isLiked
+        )
+    }
+
+    // MARK: - 생성·수정 요청
+
+    /// 초안을 서버 요청 바디로 바꾼다.
+    ///
+    /// 대표 작품은 서버 필수값이라 초안이 아직 고르지 않았으면 표시 순서 첫 작품으로 대신한다
+    /// (`effectiveRepresentativeNovelID`). 작품이 하나도 없으면 대신할 것이 없어 실패한다 —
+    /// 화면이 완료 버튼을 잠가 막지만, 계약을 어긴 요청이 서버까지 나가지 않도록 여기서도 끊는다.
+    public static func submitRequest(from draft: CollectionDraft) throws -> SubmitCollectionRequest {
+        guard let representativeNovelID = draft.effectiveRepresentativeNovelID else {
+            throw MappingError.invalidPayload(reason: "컬렉션에는 작품이 최소 하나 있어야 한다")
+        }
+
+        return SubmitCollectionRequest(
+            name: draft.name,
+            // 설명은 선택 항목이라 비어 있으면 보내지 않는다.
+            description: draft.description.isEmpty ? nil : draft.description,
+            isPublic: draft.isPrivate == false,
+            novelIds: draft.novelIDs.map(\.value),
+            representativeNovelId: representativeNovelID.value
+        )
+    }
+
+    // MARK: - 공통
+
+    private static func collectionNovel(from dto: CollectionNovelResponse) -> CollectionNovel {
+        CollectionNovel(
+            id: NovelID(dto.novelId),
+            title: dto.title,
+            author: dto.author,
+            thumbnailImage: dto.novelImage.flatMap(URL.init(string:))
+        )
+    }
+}

--- a/Projects/Data/CollectionData/Sources/Repository/DefaultCollectionRepository.swift
+++ b/Projects/Data/CollectionData/Sources/Repository/DefaultCollectionRepository.swift
@@ -1,0 +1,224 @@
+//
+//  DefaultCollectionRepository.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import CollectionDomain
+import BaseDomain
+import Networking
+import BaseData
+
+public struct DefaultCollectionRepository: CollectionRepository {
+
+    private let service: CollectionService
+    private let logger: DataLogger?
+
+    init(
+        service: CollectionService,
+        logger: DataLogger?
+    ) {
+        self.service = service
+        self.logger = logger
+    }
+
+    // MARK: - 목록
+
+    public func fetchCollectionPreviews(
+        userID: UserID,
+        size: Int
+    ) async throws(RepositoryError) -> ([CollectionPreview], Int) {
+        let action = CollectionAction.fetchCollectionPreviews(userID: userID.value)
+
+        do {
+            let response = try await service.getUserCollections(
+                userID: userID.value,
+                query: CollectionsQuery(cursor: nil, size: size)
+            )
+            let result = CollectionMapper.collectionPreviews(from: response)
+            logger?.logSuccess(action: action.name)
+            return result
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch let error as MappingError {
+            logger?.logMappingError(action: action.name, error: error)
+            throw .invalidData
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+
+    public func fetchCollections(
+        userID: UserID,
+        cursor: String?,
+        size: Int
+    ) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int) {
+        let action = CollectionAction.fetchCollections(userID: userID.value)
+
+        do {
+            let response = try await service.getUserCollections(
+                userID: userID.value,
+                query: CollectionsQuery(cursor: cursor, size: size)
+            )
+            let result = CollectionMapper.collectionCards(from: response)
+            logger?.logSuccess(action: action.name)
+            return result
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch let error as MappingError {
+            logger?.logMappingError(action: action.name, error: error)
+            throw .invalidData
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+
+    public func fetchLikedCollections(
+        cursor: String?,
+        size: Int
+    ) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int) {
+        let action = CollectionAction.fetchLikedCollections
+
+        do {
+            let response = try await service.getLikedCollections(
+                query: CollectionsQuery(cursor: cursor, size: size)
+            )
+            let result = CollectionMapper.collectionCards(from: response)
+            logger?.logSuccess(action: action.name)
+            return result
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch let error as MappingError {
+            logger?.logMappingError(action: action.name, error: error)
+            throw .invalidData
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+
+    // MARK: - 상세
+
+    public func fetchCollectionDetail(
+        id: CollectionID,
+        sortType: SortType
+    ) async throws(RepositoryError) -> CollectionDetail {
+        let action = CollectionAction.fetchCollectionDetail(collectionID: id.value)
+
+        do {
+            let response = try await service.getCollectionDetail(
+                collectionID: id.value,
+                query: CollectionDetailQuery(sortType: sortType)
+            )
+            let result = CollectionMapper.collectionDetail(from: response)
+            logger?.logSuccess(action: action.name)
+            return result
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch let error as MappingError {
+            logger?.logMappingError(action: action.name, error: error)
+            throw .invalidData
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+
+    // MARK: - 생성·수정·삭제
+
+    public func createCollection(_ draft: CollectionDraft) async throws(RepositoryError) -> CollectionID {
+        let action = CollectionAction.createCollection
+
+        do {
+            let request = try CollectionMapper.submitRequest(from: draft)
+            let response = try await service.postCollection(request: request)
+            logger?.logSuccess(action: action.name)
+            return CollectionID(response.collectionId)
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch let error as MappingError {
+            logger?.logMappingError(action: action.name, error: error)
+            throw .invalidData
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+
+    public func updateCollection(id: CollectionID, draft: CollectionDraft) async throws(RepositoryError) {
+        let action = CollectionAction.updateCollection(collectionID: id.value)
+
+        do {
+            let request = try CollectionMapper.submitRequest(from: draft)
+            try await service.putCollection(collectionID: id.value, request: request)
+            logger?.logSuccess(action: action.name)
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch let error as MappingError {
+            logger?.logMappingError(action: action.name, error: error)
+            throw .invalidData
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+
+    public func deleteCollection(id: CollectionID) async throws(RepositoryError) {
+        let action = CollectionAction.deleteCollection(collectionID: id.value)
+
+        do {
+            try await service.deleteCollection(collectionID: id.value)
+            logger?.logSuccess(action: action.name)
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+
+    // MARK: - 좋아요
+
+    public func likeCollection(id: CollectionID) async throws(RepositoryError) {
+        let action = CollectionAction.likeCollection(collectionID: id.value)
+
+        do {
+            try await service.putCollectionLike(collectionID: id.value)
+            logger?.logSuccess(action: action.name)
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+
+    public func unlikeCollection(id: CollectionID) async throws(RepositoryError) {
+        let action = CollectionAction.unlikeCollection(collectionID: id.value)
+
+        do {
+            try await service.deleteCollectionLike(collectionID: id.value)
+            logger?.logSuccess(action: action.name)
+        } catch let error as NetworkingError {
+            logger?.logNetworkError(action: action.name, error: error)
+            throw error.toRepositoryError()
+        } catch {
+            logger?.logUnknownError(action: action.name, error: error)
+            throw .unknown
+        }
+    }
+}

--- a/Projects/Data/CollectionData/Sources/Service/CollectionService.swift
+++ b/Projects/Data/CollectionData/Sources/Service/CollectionService.swift
@@ -1,0 +1,20 @@
+//
+//  CollectionService.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+public protocol CollectionService {
+    func getUserCollections(userID: Int, query: CollectionsQuery) async throws -> CollectionsResponse
+    func getLikedCollections(query: CollectionsQuery) async throws -> CollectionsResponse
+    func getCollectionDetail(collectionID: Int, query: CollectionDetailQuery) async throws -> CollectionDetailResponse
+    func postCollection(request: SubmitCollectionRequest) async throws -> CreateCollectionResponse
+    func putCollection(collectionID: Int, request: SubmitCollectionRequest) async throws
+    func deleteCollection(collectionID: Int) async throws
+    func putCollectionLike(collectionID: Int) async throws
+    func deleteCollectionLike(collectionID: Int) async throws
+}

--- a/Projects/Data/CollectionData/Sources/Service/DefaultCollectionService.swift
+++ b/Projects/Data/CollectionData/Sources/Service/DefaultCollectionService.swift
@@ -1,0 +1,67 @@
+//
+//  DefaultCollectionService.swift
+//  CollectionData
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import Networking
+
+public struct DefaultCollectionService: CollectionService {
+
+    private let network: NetworkingRequestable
+
+    init(network: NetworkingRequestable) {
+        self.network = network
+    }
+
+    public func getUserCollections(userID: Int, query: CollectionsQuery) async throws -> CollectionsResponse {
+        try await network.request(
+            CollectionEndpoint.getUserCollections(userID: userID, query),
+            decodeTo: CollectionsResponse.self
+        )
+    }
+
+    public func getLikedCollections(query: CollectionsQuery) async throws -> CollectionsResponse {
+        try await network.request(
+            CollectionEndpoint.getLikedCollections(query),
+            decodeTo: CollectionsResponse.self
+        )
+    }
+
+    public func getCollectionDetail(
+        collectionID: Int,
+        query: CollectionDetailQuery
+    ) async throws -> CollectionDetailResponse {
+        try await network.request(
+            CollectionEndpoint.getCollectionDetail(collectionID: collectionID, query),
+            decodeTo: CollectionDetailResponse.self
+        )
+    }
+
+    public func postCollection(request: SubmitCollectionRequest) async throws -> CreateCollectionResponse {
+        try await network.request(
+            CollectionEndpoint.postCollection(request),
+            decodeTo: CreateCollectionResponse.self
+        )
+    }
+
+    public func putCollection(collectionID: Int, request: SubmitCollectionRequest) async throws {
+        _ = try await network.request(CollectionEndpoint.putCollection(collectionID: collectionID, request))
+    }
+
+    public func deleteCollection(collectionID: Int) async throws {
+        _ = try await network.request(CollectionEndpoint.deleteCollection(collectionID: collectionID))
+    }
+
+    public func putCollectionLike(collectionID: Int) async throws {
+        _ = try await network.request(CollectionEndpoint.putCollectionLike(collectionID: collectionID))
+    }
+
+    public func deleteCollectionLike(collectionID: Int) async throws {
+        _ = try await network.request(CollectionEndpoint.deleteCollectionLike(collectionID: collectionID))
+    }
+}

--- a/Projects/Domain/BaseDomain/CLAUDE.md
+++ b/Projects/Domain/BaseDomain/CLAUDE.md
@@ -8,7 +8,7 @@
 ## 여기 들어있는 핵심 공통 타입
 
 - `RepositoryError` — 전 레이어 공통 에러 (Data가 여기로 변환해 throw). `notFound`(404)와 `forbidden`(403, 숨김·차단 등 "존재하나 접근 불가")은 의도적으로 분리돼 있다 — 특정 화면이 둘을 같은 취급으로 묶고 싶으면 그 화면에서 `error == .notFound || error == .forbidden`처럼 판단하고, 전역 매핑에서 섞지 말 것(FeedDetail의 "피드를 찾을 수 없어요" 알럿이 그 예).
-- `Paginated<T>` (`PaginatedWrapper`) — 페이지네이션 공통 래퍼.
+- `Paginated<T>`(`PaginatedWrapper`) / `CursorPaginated<T>` — 페이지네이션 래퍼 **두 종류**. 아래 주의사항의 "셋이 공존한다" 항목을 먼저 읽을 것.
 - `WSSIdentifiers` / `IDWrapper` — `NovelID`, `UserID`, `FeedID`, `CommentID` 등 타입 안전 ID 래퍼.
 - 공통 값 타입: `Rating`, `NovelGenre`, `Author`, `ReadingStatus`, `ReadingPeriod`, `SortType`, `AttractivePoint`, `ConnectedNovel`.
 - **Novel 서브도메인** (`Novel/`): `Novel` Entity(관심 등록 정책 포함) + `NovelRatingThreshold` + `NovelPublicationStatus`. 원래 `NovelDomain` 소유였으나 `NovelDomain`(서재·상세)과 `SearchDomain`(작품 검색) 양쪽이 참조해야 해서 이곳으로 승격했다(작품 검색을 `SearchDomain`으로 옮긴 리팩토링, 관련 배경은 `SearchDomain/CLAUDE.md` 참고).
@@ -20,6 +20,12 @@
 - `KeywordRepository`의 `fetchKeywords`/`searchKeywords`는 **로컬 DB(파일 캐시) 기반**, `syncKeywords()`는 서버→로컬 동기화이며 **`throws` 없는 `async`**(실패를 던지지 않음). **`fetchPopularKeywords`(실시간 인기 키워드)만 예외적으로 매번 서버 직접 호출** — 같은 프로토콜 안에 로컬/서버 계약이 섞여 있으니 새 메서드 추가 시 어느 쪽인지 doc comment에 명시할 것. 구현은 `BaseData`의 `DefaultKeywordRepository` 하나.
 - 키워드는 여러 도메인(Novel, Profile 등)이 캐시로 주입받아 쓴다 → Keyword 변경 시 교차 영향 확인.
 - ID는 반드시 래퍼 타입 사용. raw `Int`/`String`을 도메인 경계로 넘기지 말 것.
+- **페이지네이션 모델이 셋 공존한다 — 하나로 합치려 하지 말 것.** 서재·컬렉션은 서버가 발급한 불투명 커서(`CursorPaginated`,
+  `nextCursor`를 그대로 왕복), 피드는 `lastFeedId`(클라이언트가 마지막 항목에서 **유도**), 검색은 `page`/`size` 오프셋이다.
+  뒤 둘은 넘길 커서 자체가 없어서 `CursorPaginated`로 바꾸면 `nextCursor`가 영원히 nil인 껍데기 필드가 되고,
+  특히 피드의 `lastFeedId` 방식은 `CursorPaginated` 주석이 명시적으로 금지한 그 패턴이다.
+  → `Paginated<T>`(68곳에서 사용)를 "구식이니 지우자"고 접근하지 말 것. 서버가 커서로 통일하면 그때 다시 본다.
+  (`CursorPaginated`는 서재 전용이었으나 컬렉션도 같은 방식이라 #191에서 `NovelDomain`에서 승격했다.)
 - 화면 전용 부분집합/순서가 있는 필터 목록(예: 구 `NovelGenre.filterGenre`, `47b59a6a`에서 `WSSComponent`의 `myFeedFilter`로 이동·개명됨)은 여기 두지 않는다 — `BaseDomain`은 순수 enum만 갖고, 그런 목록은 `WSSComponent`의 `DomainPresentation` 확장(`NovelGenre+Presentation`)에 둔다.
   - ⚠️ **오래된 브랜치를 develop 위로 rebase하면 이 파일에서 `extension NovelGenre { filterGenre ... }` 형태의 충돌이 뜰 수 있다** — develop(빈 확장) 쪽이 맞다. 옛 `filterGenre`를 되살리지 말고, 그 커밋이 함께 추가한 새 목록(있다면)만 `WSSComponent`의 `DomainPresentation` 확장으로 옮겨 반영할 것.
 - `PopularKeywords`(`Keyword/Entity/`)는 실시간 인기 키워드 랭킹을 담는 별도 타입 — 랭킹은 `keywords: [Keyword]` **배열 순서로만** 표현한다(명시적 rank/count 필드 없음).

--- a/Projects/Domain/BaseDomain/Sources/CursorPaginated.swift
+++ b/Projects/Domain/BaseDomain/Sources/CursorPaginated.swift
@@ -1,6 +1,6 @@
 //
 //  CursorPaginated.swift
-//  NovelDomain
+//  BaseDomain
 //
 //  Created by YunhakLee on 7/21/26.
 //  Copyright © 2026 kr.websoso.app. All rights reserved.
@@ -12,7 +12,9 @@ import Foundation
 ///
 /// `Paginated<T>`(hasNext만 보유)로는 다음 요청에 넘길 커서를 표현할 수 없어 분리했다.
 /// 마지막 아이템 ID로 커서를 유도하지 말 것 — 커서는 서버 발급 값 그대로 왕복한다.
-/// (현재 서재 전용. 다른 도메인도 쓰게 되면 BaseDomain 승격 검토.)
+/// 서재(NovelDomain)에 이어 컬렉션도 같은 방식이라 BaseDomain으로 승격했다(#191).
+/// 단, `Paginated<T>`를 이걸로 통합하지는 말 것 — 피드는 `lastFeedId`(클라이언트가 마지막 항목에서 유도),
+/// 검색은 `page`/`size` 오프셋이라 넘길 커서가 없어서 `nextCursor`가 항상 nil인 껍데기가 된다.
 public struct CursorPaginated<T> {
     public let items: [T]
     public let hasNext: Bool

--- a/Projects/Domain/BaseDomain/Sources/WSSIdentifiers/WSSIdentifiers.swift
+++ b/Projects/Domain/BaseDomain/Sources/WSSIdentifiers/WSSIdentifiers.swift
@@ -16,3 +16,4 @@ public typealias CommentID = IDWrapper<Int>
 public typealias NotificationID = IDWrapper<Int>
 public typealias BlockID = IDWrapper<Int>
 public typealias SearchWordID = IDWrapper<Int>
+public typealias CollectionID = IDWrapper<Int>

--- a/Projects/Domain/CollectionDomain/CLAUDE.md
+++ b/Projects/Domain/CollectionDomain/CLAUDE.md
@@ -1,0 +1,33 @@
+<!-- 모듈 가이드. 이 모듈 작업 시 상위 Projects/Domain/CLAUDE.md(레이어 규칙)와 함께 자동 로드됨. -->
+# CollectionDomain
+
+사용자가 만든 작품 모음(컬렉션)의 조회·생성·수정·삭제·좋아요. 구성요소는 `Sources/`를 직접 보면 된다.
+
+- 식별자: `ModuleType.domain(.collection)` / 의존: `BaseDomain`만
+- 서버 명세: `/api-spec collection` (엔드포인트 8개가 REST Docs로 문서화돼 있다)
+
+## 핵심 시나리오
+
+- **한 응답을 두 Entity로 나눠 매핑한다.** 목록 API(`/users/{userId}/collections`)는 `representativeNovel`(대표 작품 하나)과
+  `recentNovels`(표시 순서 앞 5개)를 **항상 둘 다** 내려주고, 서버가 "무엇을 쓸지는 화면이 정하라"고 명시적으로 위임한다.
+  그 선택을 화면마다 반복하지 않도록 매핑 시점에 고정했다 → 마이페이지 섹션은 `CollectionPreview`(대표 작품만),
+  컬렉션 리스트·좋아요 목록은 `CollectionCard`(미리보기 5개).
+- **마이페이지 컬렉션 섹션에는 전용 API가 없다.** 같은 목록 API를 `size=3`으로 호출해 구성한다(서버 명세가 지시).
+  size는 상수로 박지 말고 화면이 정해 내려보낸다 — 서재에서 같은 이유로 이미 관통시킨 선례가 있다(#184).
+- **목록 반환은 `(CursorPaginated<T>, Int)` 튜플.** 두 번째 값은 응답 최상위의 `collectionsCount`(조회자가 볼 수 있는
+  **전체** 개수, 이번 페이지 개수가 아니다) — 마이페이지 "컬렉션 N개" 표시가 이 값이다. 서재와 같은 형태.
+
+## 주의사항 (작업 중 발견 시 누적)
+
+- **`isPrivate`은 서버 `isPublic`의 반대값이다.** 기획·화면 용어가 일관되게 "나만 보는 컬렉션"이라 도메인을 그 방향으로 맞췄다.
+  뒤집기는 Mapper 한 곳에서만 일어나야 한다 — Entity나 화면에서 다시 뒤집지 말 것.
+  (`FeedDetail`·`TotalFeed`는 `isPublic`으로 남아 있어 도메인 간 표기가 갈린다. 컬렉션 안에서의 일관성을 택한 결과다.)
+- **`representativeNovel`과 `recentNovels`는 배타적이지 않다.** 대표 작품이 표시 순서 앞쪽이면 양쪽에 **함께** 내려온다.
+  "대표는 미리보기에 없다"고 가정한 코드를 짜지 말 것. 걸러낼지는 화면이 정한다(서버가 걸러주지 않는다).
+- **`novelCount`는 컬렉션의 전체 작품 수**다. `recentNovels.count`(최대 5)가 아니다 — 서버 명세가 못박아 둘 만큼 흔한 혼동이다.
+- 좋아요한 컬렉션 목록 응답에는 카드마다 `likeCount`가 딸려 오지만 그 화면이 좋아요 수를 쓰지 않아 **의도적으로 매핑하지 않는다**.
+  필요해지면 `CollectionCard`에 옵셔널로 얹지 말고 그 화면 전용 타입을 두는 편이 낫다(두 목록이 같은 카드를 공유하는 구조가 깨진다).
+- 작품을 다루지만 `BaseDomain.Novel`을 쓰지 않는다 — 컬렉션 화면은 평점·관심수·장르를 쓰지 않고 서버도 주지 않아서,
+  `Novel`을 쓰면 없는 값을 0으로 채우게 된다. 경량 `CollectionNovel`을 쓴다(`LibraryNovel`·`SosoPick`과 같은 패턴).
+- 컬렉션 소유자는 `BaseDomain.Author`를, 상세 정렬은 `BaseDomain.SortType`(`recent`/`old`)을 그대로 쓴다 —
+  서버의 `owner`·`sortCriteria`와 필드가 정확히 맞아 새 타입을 만들지 않았다.

--- a/Projects/Domain/CollectionDomain/CLAUDE.md
+++ b/Projects/Domain/CollectionDomain/CLAUDE.md
@@ -29,5 +29,14 @@
   필요해지면 `CollectionCard`에 옵셔널로 얹지 말고 그 화면 전용 타입을 두는 편이 낫다(두 목록이 같은 카드를 공유하는 구조가 깨진다).
 - 작품을 다루지만 `BaseDomain.Novel`을 쓰지 않는다 — 컬렉션 화면은 평점·관심수·장르를 쓰지 않고 서버도 주지 않아서,
   `Novel`을 쓰면 없는 값을 0으로 채우게 된다. 경량 `CollectionNovel`을 쓴다(`LibraryNovel`·`SosoPick`과 같은 패턴).
+- **UseCase는 초안을 검증하지 않는다.** 제출 가능 여부(`CollectionDraft.isSubmittable`)는 완료 버튼을 잠그는 화면 몫이고,
+  UseCase가 다시 막으면 같은 규칙이 두 곳으로 갈린다(`CreateFeedUseCase`와 같은 방침). 글자 수·중복 같은 입력 제한은
+  `CollectionDraft`의 mutating 메서드가 `ValidationError`로 막는다.
+- **`CollectionDraft`의 init은 제한 초과분을 자르고, `updateName`/`updateDescription`은 던진다.** 의도적인 비대칭이다 —
+  init은 저장된 값을 되돌리는 통로라 실패하면 화면을 못 여는 반면, update는 사용자 입력이라 거부하고 이전 값을 지켜야 한다
+  (`FeedDraft`도 같은 구조).
+- **대표 작품을 고르지 않아도 제출된다.** 서버는 `representativeNovelId`를 필수로 받지만 화면에서 미지정일 수 있어,
+  `effectiveRepresentativeNovelID`가 표시 순서 첫 작품으로 대신한다. 제출할 때 이 값을 쓸 것 — `representativeNovelID`를
+  그대로 보내면 nil이 나가 서버가 거부한다.
 - 컬렉션 소유자는 `BaseDomain.Author`를, 상세 정렬은 `BaseDomain.SortType`(`recent`/`old`)을 그대로 쓴다 —
   서버의 `owner`·`sortCriteria`와 필드가 정확히 맞아 새 타입을 만들지 않았다.

--- a/Projects/Domain/CollectionDomain/Project.swift
+++ b/Projects/Domain/CollectionDomain/Project.swift
@@ -1,0 +1,16 @@
+//
+//  Project.swift
+//  AppManifests
+//
+//  Created by YunhakLee on 8/18/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.createDomainModule(
+    name: ModuleType.domain(.collection).name,
+    targets: [.sources, .testing, .tests],
+    internalDependencies: [.module(.domain(.base))]
+)

--- a/Projects/Domain/CollectionDomain/Sources/Entity/CollectionCard.swift
+++ b/Projects/Domain/CollectionDomain/Sources/Entity/CollectionCard.swift
@@ -1,0 +1,50 @@
+//
+//  CollectionCard.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+/// 컬렉션 리스트·좋아요한 컬렉션 목록의 카드. 미리보기 썸네일 줄을 보여준다.
+///
+/// 좋아요 목록 응답에는 `likeCount`가 함께 오지만 그 화면이 좋아요 수를 쓰지 않아 매핑하지 않는다.
+/// 필요해지면 이 타입에 더하지 말고 그 화면 전용 타입을 따로 두는 편이 낫다 — 두 목록이 같은 카드를 쓰는 지금 구조가 깨진다.
+public struct CollectionCard {
+
+    public let id: CollectionID
+    public let name: String
+
+    /// 없으면 nil. 서버가 설명 없는 컬렉션에 null을 내려준다.
+    public let description: String?
+
+    /// 컬렉션에 든 **전체** 작품 수. `recentNovels.count`가 아니다(미리보기는 최대 5개뿐).
+    public let novelCount: Int
+
+    /// "나만 보는 컬렉션" 여부. 서버의 `isPublic`을 뒤집은 값이다 — 기획·화면 용어가 일관되게 "나만 보는"이라
+    /// 도메인도 그 방향으로 맞췄다(뒤집기는 Mapper 한 곳에서만 일어난다).
+    public let isPrivate: Bool
+
+    /// 저장된 표시 순서 앞에서부터 최대 5개. 대표 작품을 걸러내지 않으므로 대표와 겹칠 수 있다.
+    public let recentNovels: [CollectionNovel]
+
+    public init(
+        id: CollectionID,
+        name: String,
+        description: String?,
+        novelCount: Int,
+        isPrivate: Bool,
+        recentNovels: [CollectionNovel]
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.novelCount = novelCount
+        self.isPrivate = isPrivate
+        self.recentNovels = recentNovels
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/Entity/CollectionDetail.swift
+++ b/Projects/Domain/CollectionDomain/Sources/Entity/CollectionDetail.swift
@@ -1,0 +1,92 @@
+//
+//  CollectionDetail.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+/// 컬렉션 상세 화면이 쓰는 컬렉션 전체. 목록 카드와 달리 작품이 페이지네이션 없이 전부 내려온다.
+public struct CollectionDetail {
+
+    public let id: CollectionID
+    public let name: String
+
+    /// 없으면 nil.
+    public let description: String?
+
+    public let owner: Author
+
+    /// 조회자가 소유자인지 여부. 비로그인 조회는 항상 false다.
+    /// 더보기(수정·삭제) 노출 여부가 이 값에 달려 있다.
+    public let isMine: Bool
+
+    /// "나만 보는 컬렉션" 여부. 서버 `isPublic`의 반대값.
+    /// 나만 보는 컬렉션은 공유하기 대신 비활성 배지가 나가고, 소유자에게만 보인다.
+    public let isPrivate: Bool
+
+    /// 대표 작품. 표지로 쓰이며 `novels`에 반드시 포함된다(서버가 생성·수정 시 그렇게 강제한다).
+    public let representativeNovelID: NovelID
+
+    /// 컬렉션에 든 전체 작품. 요청한 정렬 기준으로 정렬돼 오고 페이지네이션이 없다.
+    public let novels: [CollectionNovel]
+
+    /// 컬렉션이 받은 전체 좋아요 수. 조회자의 좋아요 여부와 무관하며 비공개로 바뀌어도 유지된다.
+    public private(set) var likeCount: Int
+
+    /// 조회자가 좋아요를 눌렀는지 여부. 비로그인 조회는 항상 false다.
+    /// 소유자도 자기 컬렉션에 좋아요를 누를 수 있다.
+    public private(set) var isLiked: Bool
+
+    public var novelCount: Int { novels.count }
+
+    public init(
+        id: CollectionID,
+        name: String,
+        description: String?,
+        owner: Author,
+        isMine: Bool,
+        isPrivate: Bool,
+        representativeNovelID: NovelID,
+        novels: [CollectionNovel],
+        likeCount: Int,
+        isLiked: Bool
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.owner = owner
+        self.isMine = isMine
+        self.isPrivate = isPrivate
+        self.representativeNovelID = representativeNovelID
+        self.novels = novels
+        self.likeCount = likeCount
+        self.isLiked = isLiked
+    }
+
+    // MARK: - Policy
+
+    public mutating func markAsLiked() {
+        guard isLiked == false else { return }
+        isLiked = true
+        likeCount += 1
+    }
+
+    public mutating func unmarkAsLiked() {
+        guard isLiked == true else { return }
+        isLiked = false
+        likeCount = max(0, likeCount - 1)
+    }
+
+    public mutating func toggleLike() {
+        if isLiked {
+            unmarkAsLiked()
+        } else {
+            markAsLiked()
+        }
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/Entity/CollectionDraft.swift
+++ b/Projects/Domain/CollectionDomain/Sources/Entity/CollectionDraft.swift
@@ -1,0 +1,131 @@
+//
+//  CollectionDraft.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+/// 컬렉션 만들기·수정하기 화면이 편집하는 초안. 생성과 수정이 같은 입력 계약을 쓴다.
+///
+/// 제한값은 서버가 검증해 에러로 돌려주지만(`COLLECTION-002`·`COLLECTION-004`, 이름 공백 등),
+/// 화면은 그 전에 완료 버튼을 잠가야 하므로 같은 규칙을 여기서도 판단한다 → `isSubmittable`.
+public struct CollectionDraft {
+
+    public private(set) var name: String
+    public private(set) var description: String
+    public private(set) var isPrivate: Bool
+
+    /// 담긴 작품. **배열 순서가 그대로 표시 순서로 저장된다**(앞쪽이 최신·우선).
+    /// 서버는 순서를 재정렬하지 않으므로 화면에 보이는 순서 그대로 넘겨야 한다.
+    public private(set) var novelIDs: [NovelID]
+
+    /// 카드 표지로 쓸 대표 작품. `novelIDs`에 없는 작품을 지정하면 서버가 거부한다(`COLLECTION-004`).
+    public private(set) var representativeNovelID: NovelID?
+
+    // MARK: - init
+
+    public init(
+        name: String = "",
+        description: String = "",
+        isPrivate: Bool = false,
+        novelIDs: [NovelID] = [],
+        representativeNovelID: NovelID? = nil
+    ) {
+        self.name = String(name.prefix(Self.maxNameCount))
+        self.description = String(description.prefix(Self.maxDescriptionCount))
+        self.isPrivate = isPrivate
+        self.novelIDs = Array(novelIDs.prefix(Self.maxNovelCount))
+        self.representativeNovelID = representativeNovelID
+    }
+
+    /// 수정하기 화면 진입용. 이미 저장된 컬렉션을 편집 가능한 초안으로 되돌린다.
+    public init(from detail: CollectionDetail) {
+        self.init(
+            name: detail.name,
+            description: detail.description ?? "",
+            isPrivate: detail.isPrivate,
+            novelIDs: detail.novels.map(\.id),
+            representativeNovelID: detail.representativeNovelID
+        )
+    }
+
+    // MARK: - Policy
+
+    public static let maxNameCount: Int = 20
+    public static let maxDescriptionCount: Int = 60
+    public static let minNovelCount: Int = 1
+    public static let maxNovelCount: Int = 100
+
+    public enum ValidationError: Error, Equatable {
+        case nameOverLimit(max: Int)
+        case descriptionOverLimit(max: Int)
+        case novelOverLimit(max: Int)
+        case duplicatedNovel
+        case representativeNovelNotIncluded
+    }
+
+    /// 완료 버튼 활성화 조건. 이름이 공백이 아니고 작품이 최소 하나 있으면 제출할 수 있다.
+    /// 설명은 선택 항목이라 비어 있어도 된다.
+    public var isSubmittable: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        && novelIDs.count >= Self.minNovelCount
+    }
+
+    /// 제출 시점에 서버로 보낼 대표 작품. 서버는 이 값을 필수로 요구하는데 화면에서는 아직 고르지 않았을 수 있어,
+    /// 미지정이면 표시 순서 첫 작품(= 가장 최신)을 대표로 본다.
+    public var effectiveRepresentativeNovelID: NovelID? {
+        representativeNovelID ?? novelIDs.first
+    }
+
+    public mutating func updateName(_ newValue: String) throws(ValidationError) {
+        guard newValue.count <= Self.maxNameCount else {
+            throw .nameOverLimit(max: Self.maxNameCount)
+        }
+        name = newValue
+    }
+
+    public mutating func updateDescription(_ newValue: String) throws(ValidationError) {
+        guard newValue.count <= Self.maxDescriptionCount else {
+            throw .descriptionOverLimit(max: Self.maxDescriptionCount)
+        }
+        description = newValue
+    }
+
+    public mutating func togglePrivate() {
+        isPrivate.toggle()
+    }
+
+    public mutating func addNovel(_ id: NovelID) throws(ValidationError) {
+        guard novelIDs.contains(id) == false else { throw .duplicatedNovel }
+        guard novelIDs.count < Self.maxNovelCount else {
+            throw .novelOverLimit(max: Self.maxNovelCount)
+        }
+        novelIDs.append(id)
+    }
+
+    /// 대표 작품을 지운 경우 대표 지정도 함께 풀린다 — 없는 작품을 대표로 둔 채 제출하면 서버가 거부한다.
+    public mutating func removeNovel(_ id: NovelID) {
+        novelIDs.removeAll { $0 == id }
+        if representativeNovelID == id {
+            representativeNovelID = nil
+        }
+    }
+
+    public mutating func setRepresentativeNovel(_ id: NovelID) throws(ValidationError) {
+        guard novelIDs.contains(id) else { throw .representativeNovelNotIncluded }
+        representativeNovelID = id
+    }
+
+    public func remainsNameCount() -> Int {
+        Self.maxNameCount - name.count
+    }
+
+    public func remainsDescriptionCount() -> Int {
+        Self.maxDescriptionCount - description.count
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/Entity/CollectionNovel.swift
+++ b/Projects/Domain/CollectionDomain/Sources/Entity/CollectionNovel.swift
@@ -1,0 +1,35 @@
+//
+//  CollectionNovel.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+/// 컬렉션에 담긴 작품. 서버가 컬렉션 응답 전반(카드 미리보기·상세 목록)에서 쓰는 작품 요약 구조다.
+///
+/// `BaseDomain`의 `Novel`을 재사용하지 않는 이유: 컬렉션 화면은 평점·관심수·장르를 쓰지 않고
+/// 서버도 내려주지 않는다. `Novel`을 쓰면 매핑에서 없는 값을 0으로 채워 넣게 된다.
+public struct CollectionNovel {
+
+    public let id: NovelID
+    public let title: String
+    public let author: String
+    public let thumbnailImage: URL?
+
+    public init(
+        id: NovelID,
+        title: String,
+        author: String,
+        thumbnailImage: URL?
+    ) {
+        self.id = id
+        self.title = title
+        self.author = author
+        self.thumbnailImage = thumbnailImage
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/Entity/CollectionPreview.swift
+++ b/Projects/Domain/CollectionDomain/Sources/Entity/CollectionPreview.swift
@@ -1,0 +1,36 @@
+//
+//  CollectionPreview.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+/// 마이페이지 컬렉션 섹션의 카드. 대표 작품 표지 하나만 보여준다.
+///
+/// 전용 API가 있는 게 아니라 사용자별 컬렉션 목록을 `size=3`으로 호출해 구성한다(서버 명세 지침).
+/// 같은 응답을 쓰는 `CollectionCard`와 나눠 둔 이유는 서버가 `representativeNovel`과 `recentNovels`를
+/// **둘 다** 내려주고 "무엇을 쓸지는 화면이 정하라"고 위임하기 때문이다 —
+/// 그 선택을 화면마다 반복하지 않도록 매핑 시점에 한 번 고정한다.
+public struct CollectionPreview {
+
+    public let id: CollectionID
+    public let name: String
+
+    /// 카드 표지로 쓰는 대표 작품. `recentNovels`와 독립적인 값이라 목록에 포함될 수도, 아닐 수도 있다.
+    public let representativeNovel: CollectionNovel
+
+    public init(
+        id: CollectionID,
+        name: String,
+        representativeNovel: CollectionNovel
+    ) {
+        self.id = id
+        self.name = name
+        self.representativeNovel = representativeNovel
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/Repository/CollectionRepository.swift
+++ b/Projects/Domain/CollectionDomain/Sources/Repository/CollectionRepository.swift
@@ -1,0 +1,62 @@
+//
+//  CollectionRepository.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol CollectionRepository {
+
+    /// 마이페이지 컬렉션 섹션용 미리보기 목록.
+    ///
+    /// 전용 API가 아니라 사용자별 컬렉션 목록을 앞에서 `size`개만 잘라 쓴다(현재 화면은 3개).
+    /// 무한 스크롤이 없어 커서를 쓰지 않으므로 `CursorPaginated` 대신 배열로 돌려준다.
+    /// - Returns: (미리보기 목록, 조회자가 볼 수 있는 전체 컬렉션 수)
+    func fetchCollectionPreviews(
+        userID: UserID,
+        size: Int
+    ) async throws(RepositoryError) -> ([CollectionPreview], Int)
+
+    /// 사용자별 컬렉션 목록. 최초 생성 시점 최신순.
+    ///
+    /// 본인 목록에는 나만 보는 컬렉션이 함께 오고, 다른 사용자 목록에는 공개 컬렉션만 온다
+    /// — 화면에서 걸러낼 필요가 없다.
+    /// - Parameter cursor: 직전 응답의 `nextCursor`. 첫 페이지는 nil.
+    /// - Returns: (커서 페이지, 조회자가 볼 수 있는 전체 컬렉션 수)
+    func fetchCollections(
+        userID: UserID,
+        cursor: String?,
+        size: Int
+    ) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int)
+
+    /// 좋아요한 컬렉션 목록. 좋아요한 시점 최신순.
+    /// - Returns: (커서 페이지, 전체 좋아요한 컬렉션 수)
+    func fetchLikedCollections(
+        cursor: String?,
+        size: Int
+    ) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int)
+
+    /// 컬렉션 상세. 작품은 페이지네이션 없이 전부 내려온다.
+    /// - Parameter sortType: 작품 정렬. `.recent`는 저장된 표시 순서 그대로, `.old`는 그 역순.
+    func fetchCollectionDetail(
+        id: CollectionID,
+        sortType: SortType
+    ) async throws(RepositoryError) -> CollectionDetail
+
+    /// - Returns: 생성된 컬렉션 ID
+    func createCollection(_ draft: CollectionDraft) async throws(RepositoryError) -> CollectionID
+
+    func updateCollection(id: CollectionID, draft: CollectionDraft) async throws(RepositoryError)
+
+    func deleteCollection(id: CollectionID) async throws(RepositoryError)
+
+    /// 좋아요 등록·취소는 멱등이다 — 이미 그 상태여도 서버가 에러를 내지 않는다.
+    /// 소유자도 자기 컬렉션에 좋아요를 누를 수 있다.
+    func likeCollection(id: CollectionID) async throws(RepositoryError)
+    func unlikeCollection(id: CollectionID) async throws(RepositoryError)
+}

--- a/Projects/Domain/CollectionDomain/Sources/UseCase/CollectionLikeUseCase.swift
+++ b/Projects/Domain/CollectionDomain/Sources/UseCase/CollectionLikeUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  CollectionLikeUseCase.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol CollectionLikeUseCase {
+    func like(id: CollectionID) async throws(RepositoryError)
+    func unlike(id: CollectionID) async throws(RepositoryError)
+}
+
+public final class DefaultCollectionLikeUseCase: CollectionLikeUseCase {
+
+    private let collectionRepository: CollectionRepository
+
+    public init(collectionRepository: CollectionRepository) {
+        self.collectionRepository = collectionRepository
+    }
+
+    /// 서버가 멱등이라 이미 좋아요한 컬렉션에 다시 보내도 204다 —
+    /// 화면은 현재 상태를 확신하지 못해도 "좋아요 상태로 만든다"는 의도만 보내면 된다.
+    public func like(id: CollectionID) async throws(RepositoryError) {
+        try await collectionRepository.likeCollection(id: id)
+    }
+
+    public func unlike(id: CollectionID) async throws(RepositoryError) {
+        try await collectionRepository.unlikeCollection(id: id)
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/UseCase/CreateCollectionUseCase.swift
+++ b/Projects/Domain/CollectionDomain/Sources/UseCase/CreateCollectionUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  CreateCollectionUseCase.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol CreateCollectionUseCase {
+    /// 초안으로 컬렉션을 만든다.
+    ///
+    /// 제출 가능 여부(`CollectionDraft.isSubmittable`) 판단은 화면 몫이다 —
+    /// 완료 버튼을 잠그는 것도 같은 규칙이라 여기서 다시 막으면 규칙이 두 곳으로 갈린다.
+    /// - Returns: 생성된 컬렉션 ID
+    func execute(_ draft: CollectionDraft) async throws(RepositoryError) -> CollectionID
+}
+
+public final class DefaultCreateCollectionUseCase: CreateCollectionUseCase {
+
+    private let collectionRepository: CollectionRepository
+
+    public init(collectionRepository: CollectionRepository) {
+        self.collectionRepository = collectionRepository
+    }
+
+    public func execute(_ draft: CollectionDraft) async throws(RepositoryError) -> CollectionID {
+        try await collectionRepository.createCollection(draft)
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/UseCase/DeleteCollectionUseCase.swift
+++ b/Projects/Domain/CollectionDomain/Sources/UseCase/DeleteCollectionUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  DeleteCollectionUseCase.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol DeleteCollectionUseCase {
+    /// 컬렉션을 삭제한다. 담긴 작품 자체는 지워지지 않는다(컬렉션에서 빠질 뿐).
+    func execute(id: CollectionID) async throws(RepositoryError)
+}
+
+public final class DefaultDeleteCollectionUseCase: DeleteCollectionUseCase {
+
+    private let collectionRepository: CollectionRepository
+
+    public init(collectionRepository: CollectionRepository) {
+        self.collectionRepository = collectionRepository
+    }
+
+    public func execute(id: CollectionID) async throws(RepositoryError) {
+        try await collectionRepository.deleteCollection(id: id)
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/UseCase/LoadCollectionDetailUseCase.swift
+++ b/Projects/Domain/CollectionDomain/Sources/UseCase/LoadCollectionDetailUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  LoadCollectionDetailUseCase.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol LoadCollectionDetailUseCase {
+    /// 컬렉션 상세를 가져온다. 작품은 페이지네이션 없이 전부 온다.
+    /// - Parameter sortType: 화면의 "등록 최신순 / 등록 오래된순" 토글. 정렬을 바꾸면 다시 호출한다.
+    func execute(id: CollectionID, sortType: SortType) async throws(RepositoryError) -> CollectionDetail
+}
+
+public final class DefaultLoadCollectionDetailUseCase: LoadCollectionDetailUseCase {
+
+    private let collectionRepository: CollectionRepository
+
+    public init(collectionRepository: CollectionRepository) {
+        self.collectionRepository = collectionRepository
+    }
+
+    public func execute(id: CollectionID, sortType: SortType) async throws(RepositoryError) -> CollectionDetail {
+        try await collectionRepository.fetchCollectionDetail(id: id, sortType: sortType)
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/UseCase/LoadCollectionPreviewsUseCase.swift
+++ b/Projects/Domain/CollectionDomain/Sources/UseCase/LoadCollectionPreviewsUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  LoadCollectionPreviewsUseCase.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol LoadCollectionPreviewsUseCase {
+    /// 마이페이지 컬렉션 섹션에 보여줄 미리보기를 가져온다.
+    ///
+    /// 전용 API가 없어 사용자별 컬렉션 목록을 앞에서 `size`개만 잘라 쓴다.
+    /// `size`를 상수로 박지 않는 이유는 화면이 몇 개를 보여줄지 정하기 때문이다(서재도 같은 이유로 관통시켰다).
+    /// - Returns: (미리보기 목록, 전체 컬렉션 수 — 섹션 상단의 "컬렉션 N개")
+    func execute(userID: UserID, size: Int) async throws(RepositoryError) -> ([CollectionPreview], Int)
+}
+
+public final class DefaultLoadCollectionPreviewsUseCase: LoadCollectionPreviewsUseCase {
+
+    private let collectionRepository: CollectionRepository
+
+    public init(collectionRepository: CollectionRepository) {
+        self.collectionRepository = collectionRepository
+    }
+
+    public func execute(userID: UserID, size: Int) async throws(RepositoryError) -> ([CollectionPreview], Int) {
+        try await collectionRepository.fetchCollectionPreviews(userID: userID, size: size)
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/UseCase/LoadCollectionsUseCase.swift
+++ b/Projects/Domain/CollectionDomain/Sources/UseCase/LoadCollectionsUseCase.swift
@@ -1,0 +1,32 @@
+//
+//  LoadCollectionsUseCase.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol LoadCollectionsUseCase {
+    /// 사용자별 컬렉션 목록을 가져온다. 본인 목록에는 나만 보는 컬렉션이 함께 오고,
+    /// 다른 사용자 목록에는 공개 컬렉션만 오므로 화면에서 따로 거를 필요가 없다.
+    /// - Parameter cursor: 직전 응답의 `nextCursor`. 첫 페이지는 nil.
+    /// - Returns: (커서 페이지, 전체 컬렉션 수)
+    func execute(userID: UserID, cursor: String?, size: Int) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int)
+}
+
+public final class DefaultLoadCollectionsUseCase: LoadCollectionsUseCase {
+
+    private let collectionRepository: CollectionRepository
+
+    public init(collectionRepository: CollectionRepository) {
+        self.collectionRepository = collectionRepository
+    }
+
+    public func execute(userID: UserID, cursor: String?, size: Int) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int) {
+        try await collectionRepository.fetchCollections(userID: userID, cursor: cursor, size: size)
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/UseCase/LoadLikedCollectionsUseCase.swift
+++ b/Projects/Domain/CollectionDomain/Sources/UseCase/LoadLikedCollectionsUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  LoadLikedCollectionsUseCase.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol LoadLikedCollectionsUseCase {
+    /// 좋아요한 컬렉션 목록을 가져온다. 좋아요한 시점 최신순.
+    /// - Parameter cursor: 직전 응답의 `nextCursor`. 첫 페이지는 nil.
+    /// - Returns: (커서 페이지, 전체 좋아요한 컬렉션 수)
+    func execute(cursor: String?, size: Int) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int)
+}
+
+public final class DefaultLoadLikedCollectionsUseCase: LoadLikedCollectionsUseCase {
+
+    private let collectionRepository: CollectionRepository
+
+    public init(collectionRepository: CollectionRepository) {
+        self.collectionRepository = collectionRepository
+    }
+
+    public func execute(cursor: String?, size: Int) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int) {
+        try await collectionRepository.fetchLikedCollections(cursor: cursor, size: size)
+    }
+}

--- a/Projects/Domain/CollectionDomain/Sources/UseCase/UpdateCollectionUseCase.swift
+++ b/Projects/Domain/CollectionDomain/Sources/UseCase/UpdateCollectionUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  UpdateCollectionUseCase.swift
+//  CollectionDomain
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public protocol UpdateCollectionUseCase {
+    /// 컬렉션을 수정한다. 부분 수정이 아니라 초안 전체를 덮어쓴다 —
+    /// 작품 목록도 통째로 다시 보내므로, 화면은 편집 결과 전체를 담은 초안을 넘겨야 한다.
+    func execute(id: CollectionID, draft: CollectionDraft) async throws(RepositoryError)
+}
+
+public final class DefaultUpdateCollectionUseCase: UpdateCollectionUseCase {
+
+    private let collectionRepository: CollectionRepository
+
+    public init(collectionRepository: CollectionRepository) {
+        self.collectionRepository = collectionRepository
+    }
+
+    public func execute(id: CollectionID, draft: CollectionDraft) async throws(RepositoryError) {
+        try await collectionRepository.updateCollection(id: id, draft: draft)
+    }
+}

--- a/Projects/Domain/CollectionDomain/Testing/Mock/MockCollectionRepository.swift
+++ b/Projects/Domain/CollectionDomain/Testing/Mock/MockCollectionRepository.swift
@@ -1,0 +1,101 @@
+//
+//  MockCollectionRepository.swift
+//  CollectionDomainTesting
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+import CollectionDomain
+
+public final class MockCollectionRepository: CollectionRepository {
+
+    // MARK: - 주입할 결과
+
+    public var fetchCollectionPreviewsResult: Result<([CollectionPreview], Int), RepositoryError>!
+    public var fetchCollectionsResult: Result<(CursorPaginated<CollectionCard>, Int), RepositoryError>!
+    public var fetchLikedCollectionsResult: Result<(CursorPaginated<CollectionCard>, Int), RepositoryError>!
+    public var fetchCollectionDetailResult: Result<CollectionDetail, RepositoryError>!
+    public var createCollectionResult: Result<CollectionID, RepositoryError>!
+    public var updateCollectionResult: Result<Void, RepositoryError> = .success(())
+    public var deleteCollectionResult: Result<Void, RepositoryError> = .success(())
+    public var likeCollectionResult: Result<Void, RepositoryError> = .success(())
+    public var unlikeCollectionResult: Result<Void, RepositoryError> = .success(())
+
+    // MARK: - 호출 기록
+
+    public private(set) var fetchedPreviewRequests: [(userID: UserID, size: Int)] = []
+    public private(set) var fetchedCollectionRequests: [(userID: UserID, cursor: String?, size: Int)] = []
+    public private(set) var fetchedLikedRequests: [(cursor: String?, size: Int)] = []
+    public private(set) var fetchedDetailRequests: [(id: CollectionID, sortType: SortType)] = []
+    public private(set) var createdDrafts: [CollectionDraft] = []
+    public private(set) var updatedRequests: [(id: CollectionID, draft: CollectionDraft)] = []
+    public private(set) var deletedIDs: [CollectionID] = []
+    public private(set) var likedIDs: [CollectionID] = []
+    public private(set) var unlikedIDs: [CollectionID] = []
+
+    public init() {}
+
+    // MARK: - CollectionRepository
+
+    public func fetchCollectionPreviews(
+        userID: UserID,
+        size: Int
+    ) async throws(RepositoryError) -> ([CollectionPreview], Int) {
+        fetchedPreviewRequests.append((userID, size))
+        return try fetchCollectionPreviewsResult.get()
+    }
+
+    public func fetchCollections(
+        userID: UserID,
+        cursor: String?,
+        size: Int
+    ) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int) {
+        fetchedCollectionRequests.append((userID, cursor, size))
+        return try fetchCollectionsResult.get()
+    }
+
+    public func fetchLikedCollections(
+        cursor: String?,
+        size: Int
+    ) async throws(RepositoryError) -> (CursorPaginated<CollectionCard>, Int) {
+        fetchedLikedRequests.append((cursor, size))
+        return try fetchLikedCollectionsResult.get()
+    }
+
+    public func fetchCollectionDetail(
+        id: CollectionID,
+        sortType: SortType
+    ) async throws(RepositoryError) -> CollectionDetail {
+        fetchedDetailRequests.append((id, sortType))
+        return try fetchCollectionDetailResult.get()
+    }
+
+    public func createCollection(_ draft: CollectionDraft) async throws(RepositoryError) -> CollectionID {
+        createdDrafts.append(draft)
+        return try createCollectionResult.get()
+    }
+
+    public func updateCollection(id: CollectionID, draft: CollectionDraft) async throws(RepositoryError) {
+        updatedRequests.append((id, draft))
+        try updateCollectionResult.get()
+    }
+
+    public func deleteCollection(id: CollectionID) async throws(RepositoryError) {
+        deletedIDs.append(id)
+        try deleteCollectionResult.get()
+    }
+
+    public func likeCollection(id: CollectionID) async throws(RepositoryError) {
+        likedIDs.append(id)
+        try likeCollectionResult.get()
+    }
+
+    public func unlikeCollection(id: CollectionID) async throws(RepositoryError) {
+        unlikedIDs.append(id)
+        try unlikeCollectionResult.get()
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/Entity/CollectionDetailTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/Entity/CollectionDetailTests.swift
@@ -1,0 +1,127 @@
+//
+//  CollectionDetailTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import BaseDomain
+
+@Suite("CollectionDetail")
+struct CollectionDetailTests {
+
+    // MARK: - markAsLiked
+
+    @Test("좋아요하지 않은 컬렉션을 좋아요하면 상태가 켜지고 좋아요 수가 늘어난다")
+    func markAsLiked() {
+        var detail = makeDetail(likeCount: 10, isLiked: false)
+
+        detail.markAsLiked()
+
+        #expect(detail.isLiked)
+        #expect(detail.likeCount == 11)
+    }
+
+    @Test("이미 좋아요한 컬렉션에 markAsLiked를 호출하면 좋아요 수가 중복으로 늘지 않는다")
+    func markAsLikedTwice() {
+        var detail = makeDetail(likeCount: 10, isLiked: true)
+
+        detail.markAsLiked()
+
+        #expect(detail.isLiked)
+        #expect(detail.likeCount == 10)
+    }
+
+    // MARK: - unmarkAsLiked
+
+    @Test("좋아요한 컬렉션을 취소하면 상태가 꺼지고 좋아요 수가 줄어든다")
+    func unmarkAsLiked() {
+        var detail = makeDetail(likeCount: 10, isLiked: true)
+
+        detail.unmarkAsLiked()
+
+        #expect(detail.isLiked == false)
+        #expect(detail.likeCount == 9)
+    }
+
+    @Test("좋아요하지 않은 컬렉션에 unmarkAsLiked를 호출하면 좋아요 수가 줄지 않는다")
+    func unmarkAsLikedWhenNotLiked() {
+        var detail = makeDetail(likeCount: 10, isLiked: false)
+
+        detail.unmarkAsLiked()
+
+        #expect(detail.isLiked == false)
+        #expect(detail.likeCount == 10)
+    }
+
+    @Test("좋아요 수가 0인 상태에서 취소해도 좋아요 수가 음수로 내려가지 않는다")
+    func unmarkAsLikedAtZero() {
+        var detail = makeDetail(likeCount: 0, isLiked: true)
+
+        detail.unmarkAsLiked()
+
+        #expect(detail.likeCount == 0)
+    }
+
+    // MARK: - toggleLike
+
+    @Test("좋아요하지 않은 컬렉션을 토글하면 좋아요 상태가 된다")
+    func toggleLikeOn() {
+        var detail = makeDetail(likeCount: 3, isLiked: false)
+
+        detail.toggleLike()
+
+        #expect(detail.isLiked)
+        #expect(detail.likeCount == 4)
+    }
+
+    @Test("좋아요한 컬렉션을 토글하면 좋아요가 취소된다")
+    func toggleLikeOff() {
+        var detail = makeDetail(likeCount: 3, isLiked: true)
+
+        detail.toggleLike()
+
+        #expect(detail.isLiked == false)
+        #expect(detail.likeCount == 2)
+    }
+
+    // MARK: - novelCount
+
+    @Test("작품 수는 담긴 작품 목록의 길이와 같다")
+    func novelCountMatchesNovels() {
+        let detail = makeDetail(novelCount: 3)
+
+        #expect(detail.novelCount == 3)
+    }
+}
+
+// MARK: - Helper
+
+private extension CollectionDetailTests {
+
+    func makeDetail(
+        novelCount: Int = 1,
+        likeCount: Int = 0,
+        isLiked: Bool = false
+    ) -> CollectionDetail {
+        CollectionDetail(
+            id: CollectionID(1),
+            name: "취향 저격 로판",
+            description: nil,
+            owner: Author(userId: UserID(1), nickname: "웹소소", profileImage: nil),
+            isMine: false,
+            isPrivate: false,
+            representativeNovelID: NovelID(1),
+            novels: (1...max(1, novelCount)).map {
+                CollectionNovel(id: NovelID($0), title: "작품", author: "작가", thumbnailImage: nil)
+            },
+            likeCount: likeCount,
+            isLiked: isLiked
+        )
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/Entity/CollectionDraftTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/Entity/CollectionDraftTests.swift
@@ -1,0 +1,309 @@
+//
+//  CollectionDraftTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import BaseDomain
+
+@Suite("CollectionDraft")
+struct CollectionDraftTests {
+
+    // MARK: - isSubmittable
+
+    @Test("이름이 있고 작품이 하나 이상이면 제출할 수 있다")
+    func submittableWithNameAndNovel() {
+        let draft = makeDraft(name: "취향 저격 로판", novelIDs: [NovelID(1)])
+
+        #expect(draft.isSubmittable)
+    }
+
+    @Test("설명은 선택 항목이라 비어 있어도 제출할 수 있다")
+    func submittableWithoutDescription() {
+        let draft = makeDraft(name: "취향 저격 로판", description: "", novelIDs: [NovelID(1)])
+
+        #expect(draft.isSubmittable)
+    }
+
+    @Test("이름이 비어 있으면 제출할 수 없다")
+    func notSubmittableWithoutName() {
+        let draft = makeDraft(name: "", novelIDs: [NovelID(1)])
+
+        #expect(draft.isSubmittable == false)
+    }
+
+    @Test("이름이 공백 문자뿐이면 제출할 수 없다")
+    func notSubmittableWithBlankName() {
+        let draft = makeDraft(name: "   ", novelIDs: [NovelID(1)])
+
+        #expect(draft.isSubmittable == false)
+    }
+
+    @Test("작품이 하나도 없으면 제출할 수 없다")
+    func notSubmittableWithoutNovel() {
+        let draft = makeDraft(name: "취향 저격 로판", novelIDs: [])
+
+        #expect(draft.isSubmittable == false)
+    }
+
+    // MARK: - updateName
+
+    @Test("이름을 20자까지는 입력할 수 있다")
+    func updateNameAtLimit() throws {
+        var draft = makeDraft()
+
+        try draft.updateName(String(repeating: "가", count: 20))
+
+        #expect(draft.name.count == 20)
+    }
+
+    @Test("이름이 20자를 넘으면 입력이 거부되고 이전 값이 남는다")
+    func updateNameOverLimit() {
+        var draft = makeDraft(name: "원래 이름")
+
+        #expect(throws: CollectionDraft.ValidationError.nameOverLimit(max: 20)) {
+            try draft.updateName(String(repeating: "가", count: 21))
+        }
+        #expect(draft.name == "원래 이름")
+    }
+
+    @Test("이름 남은 글자 수는 20에서 현재 길이를 뺀 값이다")
+    func remainsNameCount() throws {
+        var draft = makeDraft()
+
+        try draft.updateName("다섯글자야")
+
+        #expect(draft.remainsNameCount() == 15)
+    }
+
+    // MARK: - updateDescription
+
+    @Test("설명을 60자까지는 입력할 수 있다")
+    func updateDescriptionAtLimit() throws {
+        var draft = makeDraft()
+
+        try draft.updateDescription(String(repeating: "가", count: 60))
+
+        #expect(draft.description.count == 60)
+    }
+
+    @Test("설명이 60자를 넘으면 입력이 거부된다")
+    func updateDescriptionOverLimit() {
+        var draft = makeDraft()
+
+        #expect(throws: CollectionDraft.ValidationError.descriptionOverLimit(max: 60)) {
+            try draft.updateDescription(String(repeating: "가", count: 61))
+        }
+    }
+
+    // MARK: - init
+
+    @Test("저장된 값으로 초안을 만들 때 제한을 넘는 이름은 잘려서 들어온다")
+    func initTruncatesOverLimitName() {
+        let draft = makeDraft(name: String(repeating: "가", count: 25))
+
+        #expect(draft.name.count == 20)
+    }
+
+    @Test("수정하기 화면은 기존 컬렉션을 그대로 편집 가능한 초안으로 되돌린다")
+    func initFromDetail() {
+        let detail = makeDetail(
+            name: "취향 저격 로판",
+            description: "여주가 강한 로맨스 판타지",
+            isPrivate: true,
+            novelIDs: [NovelID(9), NovelID(5)],
+            representativeNovelID: NovelID(5)
+        )
+
+        let draft = CollectionDraft(from: detail)
+
+        #expect(draft.name == "취향 저격 로판")
+        #expect(draft.description == "여주가 강한 로맨스 판타지")
+        #expect(draft.isPrivate)
+        #expect(draft.novelIDs == [NovelID(9), NovelID(5)])
+        #expect(draft.representativeNovelID == NovelID(5))
+    }
+
+    @Test("설명이 없던 컬렉션을 초안으로 되돌리면 설명은 빈 문자열이 된다")
+    func initFromDetailWithoutDescription() {
+        let detail = makeDetail(description: nil)
+
+        let draft = CollectionDraft(from: detail)
+
+        #expect(draft.description.isEmpty)
+    }
+
+    // MARK: - addNovel
+
+    @Test("작품을 추가하면 표시 순서 끝에 붙는다")
+    func addNovelAppends() throws {
+        var draft = makeDraft(novelIDs: [NovelID(1)])
+
+        try draft.addNovel(NovelID(2))
+
+        #expect(draft.novelIDs == [NovelID(1), NovelID(2)])
+    }
+
+    @Test("이미 담긴 작품은 다시 추가할 수 없다")
+    func addDuplicatedNovel() {
+        var draft = makeDraft(novelIDs: [NovelID(1)])
+
+        #expect(throws: CollectionDraft.ValidationError.duplicatedNovel) {
+            try draft.addNovel(NovelID(1))
+        }
+        #expect(draft.novelIDs.count == 1)
+    }
+
+    @Test("작품이 100개면 더 추가할 수 없다")
+    func addNovelOverLimit() {
+        var draft = makeDraft(novelIDs: (1...100).map { NovelID($0) })
+
+        #expect(throws: CollectionDraft.ValidationError.novelOverLimit(max: 100)) {
+            try draft.addNovel(NovelID(101))
+        }
+    }
+
+    // MARK: - removeNovel
+
+    @Test("작품을 빼면 목록에서 사라진다")
+    func removeNovel() {
+        var draft = makeDraft(novelIDs: [NovelID(1), NovelID(2)])
+
+        draft.removeNovel(NovelID(1))
+
+        #expect(draft.novelIDs == [NovelID(2)])
+    }
+
+    @Test("대표로 지정한 작품을 빼면 대표 지정도 함께 풀린다")
+    func removeRepresentativeNovel() throws {
+        var draft = makeDraft(novelIDs: [NovelID(1), NovelID(2)])
+        try draft.setRepresentativeNovel(NovelID(1))
+
+        draft.removeNovel(NovelID(1))
+
+        #expect(draft.representativeNovelID == nil)
+    }
+
+    @Test("대표가 아닌 작품을 빼면 대표 지정은 그대로 남는다")
+    func removeNonRepresentativeNovel() throws {
+        var draft = makeDraft(novelIDs: [NovelID(1), NovelID(2)])
+        try draft.setRepresentativeNovel(NovelID(1))
+
+        draft.removeNovel(NovelID(2))
+
+        #expect(draft.representativeNovelID == NovelID(1))
+    }
+
+    // MARK: - setRepresentativeNovel
+
+    @Test("담긴 작품 중 하나를 대표로 지정할 수 있다")
+    func setRepresentativeNovel() throws {
+        var draft = makeDraft(novelIDs: [NovelID(1), NovelID(2)])
+
+        try draft.setRepresentativeNovel(NovelID(2))
+
+        #expect(draft.representativeNovelID == NovelID(2))
+    }
+
+    @Test("담기지 않은 작품은 대표로 지정할 수 없다")
+    func setRepresentativeNovelNotIncluded() {
+        var draft = makeDraft(novelIDs: [NovelID(1)])
+
+        #expect(throws: CollectionDraft.ValidationError.representativeNovelNotIncluded) {
+            try draft.setRepresentativeNovel(NovelID(99))
+        }
+    }
+
+    // MARK: - effectiveRepresentativeNovelID
+
+    @Test("대표를 고르지 않았으면 표시 순서 첫 작품이 대표가 된다")
+    func effectiveRepresentativeFallsBackToFirst() {
+        let draft = makeDraft(novelIDs: [NovelID(7), NovelID(3)])
+
+        #expect(draft.effectiveRepresentativeNovelID == NovelID(7))
+    }
+
+    @Test("대표를 골랐으면 첫 작품이 아니라 고른 작품이 대표가 된다")
+    func effectiveRepresentativeUsesChosen() throws {
+        var draft = makeDraft(novelIDs: [NovelID(7), NovelID(3)])
+
+        try draft.setRepresentativeNovel(NovelID(3))
+
+        #expect(draft.effectiveRepresentativeNovelID == NovelID(3))
+    }
+
+    @Test("작품이 하나도 없으면 대표도 없다")
+    func effectiveRepresentativeWithoutNovel() {
+        let draft = makeDraft(novelIDs: [])
+
+        #expect(draft.effectiveRepresentativeNovelID == nil)
+    }
+
+    // MARK: - togglePrivate
+
+    @Test("나만 보는 컬렉션은 기본적으로 꺼져 있다")
+    func privateIsOffByDefault() {
+        let draft = CollectionDraft()
+
+        #expect(draft.isPrivate == false)
+    }
+
+    @Test("나만 보기를 토글하면 상태가 뒤집힌다")
+    func togglePrivate() {
+        var draft = makeDraft()
+
+        draft.togglePrivate()
+
+        #expect(draft.isPrivate)
+    }
+}
+
+// MARK: - Helper
+
+private extension CollectionDraftTests {
+
+    func makeDraft(
+        name: String = "컬렉션",
+        description: String = "설명",
+        isPrivate: Bool = false,
+        novelIDs: [NovelID] = [NovelID(1)],
+        representativeNovelID: NovelID? = nil
+    ) -> CollectionDraft {
+        CollectionDraft(
+            name: name,
+            description: description,
+            isPrivate: isPrivate,
+            novelIDs: novelIDs,
+            representativeNovelID: representativeNovelID
+        )
+    }
+
+    func makeDetail(
+        name: String = "컬렉션",
+        description: String? = "설명",
+        isPrivate: Bool = false,
+        novelIDs: [NovelID] = [NovelID(1)],
+        representativeNovelID: NovelID = NovelID(1)
+    ) -> CollectionDetail {
+        CollectionDetail(
+            id: CollectionID(1),
+            name: name,
+            description: description,
+            owner: Author(userId: UserID(1), nickname: "웹소소", profileImage: nil),
+            isMine: true,
+            isPrivate: isPrivate,
+            representativeNovelID: representativeNovelID,
+            novels: novelIDs.map {
+                CollectionNovel(id: $0, title: "작품", author: "작가", thumbnailImage: nil)
+            },
+            likeCount: 0,
+            isLiked: false
+        )
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/UseCase/CollectionLikeUseCaseTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/UseCase/CollectionLikeUseCaseTests.swift
@@ -1,0 +1,73 @@
+//
+//  CollectionLikeUseCaseTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import CollectionDomainTesting
+import BaseDomain
+
+@Suite("CollectionLikeUseCase")
+struct CollectionLikeUseCaseTests {
+
+    @Test("좋아요를 누르면 해당 컬렉션 ID로 등록을 요청한다")
+    func likeSuccess() async throws {
+        let mock = MockCollectionRepository()
+        let useCase = DefaultCollectionLikeUseCase(collectionRepository: mock)
+
+        try await useCase.like(id: CollectionID(31))
+
+        #expect(mock.likedIDs == [CollectionID(31)])
+        #expect(mock.unlikedIDs.isEmpty)
+    }
+
+    @Test("좋아요를 취소하면 해당 컬렉션 ID로 취소를 요청한다")
+    func unlikeSuccess() async throws {
+        let mock = MockCollectionRepository()
+        let useCase = DefaultCollectionLikeUseCase(collectionRepository: mock)
+
+        try await useCase.unlike(id: CollectionID(31))
+
+        #expect(mock.unlikedIDs == [CollectionID(31)])
+        #expect(mock.likedIDs.isEmpty)
+    }
+
+    @Test("서버가 멱등이라 같은 좋아요를 두 번 보내도 그대로 두 번 요청한다")
+    func likeIsIdempotentOnServer() async throws {
+        let mock = MockCollectionRepository()
+        let useCase = DefaultCollectionLikeUseCase(collectionRepository: mock)
+
+        try await useCase.like(id: CollectionID(31))
+        try await useCase.like(id: CollectionID(31))
+
+        #expect(mock.likedIDs == [CollectionID(31), CollectionID(31)])
+    }
+
+    @Test("볼 수 없는 컬렉션에 좋아요를 누르면 forbidden을 전달한다")
+    func likeForbidden() async {
+        let mock = MockCollectionRepository()
+        mock.likeCollectionResult = .failure(.forbidden)
+        let useCase = DefaultCollectionLikeUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.forbidden) {
+            try await useCase.like(id: CollectionID(31))
+        }
+    }
+
+    @Test("좋아요 취소에 실패하면 에러를 그대로 전달한다")
+    func unlikeFailure() async {
+        let mock = MockCollectionRepository()
+        mock.unlikeCollectionResult = .failure(.networkUnavailable)
+        let useCase = DefaultCollectionLikeUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.networkUnavailable) {
+            try await useCase.unlike(id: CollectionID(31))
+        }
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/UseCase/CreateCollectionUseCaseTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/UseCase/CreateCollectionUseCaseTests.swift
@@ -1,0 +1,77 @@
+//
+//  CreateCollectionUseCaseTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import CollectionDomainTesting
+import BaseDomain
+
+@Suite("CreateCollectionUseCase")
+struct CreateCollectionUseCaseTests {
+
+    @Test("컬렉션을 만들면 생성된 컬렉션 ID를 돌려준다")
+    func createSuccess() async throws {
+        let mock = MockCollectionRepository()
+        mock.createCollectionResult = .success(CollectionID(12))
+        let useCase = DefaultCreateCollectionUseCase(collectionRepository: mock)
+
+        let id = try await useCase.execute(makeDraft())
+
+        #expect(id == CollectionID(12))
+        #expect(mock.createdDrafts.count == 1)
+    }
+
+    @Test("작품의 표시 순서가 초안 그대로 전달된다")
+    func preservesNovelOrder() async throws {
+        let mock = MockCollectionRepository()
+        mock.createCollectionResult = .success(CollectionID(1))
+        let useCase = DefaultCreateCollectionUseCase(collectionRepository: mock)
+
+        _ = try await useCase.execute(makeDraft(novelIDs: [NovelID(9), NovelID(5), NovelID(3)]))
+
+        #expect(mock.createdDrafts.last?.novelIDs == [NovelID(9), NovelID(5), NovelID(3)])
+    }
+
+    @Test("나만 보는 설정이 초안 그대로 전달된다")
+    func passesPrivacy() async throws {
+        let mock = MockCollectionRepository()
+        mock.createCollectionResult = .success(CollectionID(1))
+        let useCase = DefaultCreateCollectionUseCase(collectionRepository: mock)
+
+        _ = try await useCase.execute(makeDraft(isPrivate: true))
+
+        #expect(mock.createdDrafts.last?.isPrivate == true)
+    }
+
+    @Test("생성에 실패하면 에러를 그대로 전달한다")
+    func createFailure() async {
+        let mock = MockCollectionRepository()
+        mock.createCollectionResult = .failure(.invalidData)
+        let useCase = DefaultCreateCollectionUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.invalidData) {
+            try await useCase.execute(makeDraft())
+        }
+    }
+}
+
+private extension CreateCollectionUseCaseTests {
+    func makeDraft(
+        isPrivate: Bool = false,
+        novelIDs: [NovelID] = [NovelID(1)]
+    ) -> CollectionDraft {
+        CollectionDraft(
+            name: "취향 저격 로판",
+            description: "여주가 강한 로맨스 판타지",
+            isPrivate: isPrivate,
+            novelIDs: novelIDs
+        )
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/UseCase/DeleteCollectionUseCaseTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/UseCase/DeleteCollectionUseCaseTests.swift
@@ -1,0 +1,39 @@
+//
+//  DeleteCollectionUseCaseTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import CollectionDomainTesting
+import BaseDomain
+
+@Suite("DeleteCollectionUseCase")
+struct DeleteCollectionUseCaseTests {
+
+    @Test("삭제하려는 컬렉션 ID가 전달된다")
+    func deleteSuccess() async throws {
+        let mock = MockCollectionRepository()
+        let useCase = DefaultDeleteCollectionUseCase(collectionRepository: mock)
+
+        try await useCase.execute(id: CollectionID(31))
+
+        #expect(mock.deletedIDs == [CollectionID(31)])
+    }
+
+    @Test("삭제에 실패하면 에러를 그대로 전달한다")
+    func deleteFailure() async {
+        let mock = MockCollectionRepository()
+        mock.deleteCollectionResult = .failure(.notFound)
+        let useCase = DefaultDeleteCollectionUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.notFound) {
+            try await useCase.execute(id: CollectionID(31))
+        }
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/UseCase/LoadCollectionDetailUseCaseTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/UseCase/LoadCollectionDetailUseCaseTests.swift
@@ -1,0 +1,80 @@
+//
+//  LoadCollectionDetailUseCaseTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import CollectionDomainTesting
+import BaseDomain
+
+@Suite("LoadCollectionDetailUseCase")
+struct LoadCollectionDetailUseCaseTests {
+
+    @Test("컬렉션 상세를 불러온다")
+    func loadSuccess() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionDetailResult = .success(makeDetail(name: "취향 저격 로판"))
+        let useCase = DefaultLoadCollectionDetailUseCase(collectionRepository: mock)
+
+        let detail = try await useCase.execute(id: CollectionID(31), sortType: .recent)
+
+        #expect(detail.name == "취향 저격 로판")
+    }
+
+    @Test("화면이 고른 정렬 기준이 그대로 전달된다")
+    func passesSortType() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionDetailResult = .success(makeDetail())
+        let useCase = DefaultLoadCollectionDetailUseCase(collectionRepository: mock)
+
+        _ = try await useCase.execute(id: CollectionID(31), sortType: .old)
+
+        #expect(mock.fetchedDetailRequests.last?.sortType == .old)
+        #expect(mock.fetchedDetailRequests.last?.id == CollectionID(31))
+    }
+
+    @Test("없는 컬렉션을 조회하면 notFound를 전달한다")
+    func loadNotFound() async {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionDetailResult = .failure(.notFound)
+        let useCase = DefaultLoadCollectionDetailUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.notFound) {
+            try await useCase.execute(id: CollectionID(99), sortType: .recent)
+        }
+    }
+
+    @Test("남의 나만 보는 컬렉션을 조회하면 forbidden을 전달한다")
+    func loadForbidden() async {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionDetailResult = .failure(.forbidden)
+        let useCase = DefaultLoadCollectionDetailUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.forbidden) {
+            try await useCase.execute(id: CollectionID(31), sortType: .recent)
+        }
+    }
+}
+
+private extension LoadCollectionDetailUseCaseTests {
+    func makeDetail(name: String = "컬렉션") -> CollectionDetail {
+        CollectionDetail(
+            id: CollectionID(31),
+            name: name,
+            description: nil,
+            owner: Author(userId: UserID(7), nickname: "웹소소", profileImage: nil),
+            isMine: true,
+            isPrivate: false,
+            representativeNovelID: NovelID(1),
+            novels: [CollectionNovel(id: NovelID(1), title: "작품", author: "작가", thumbnailImage: nil)],
+            likeCount: 0,
+            isLiked: false
+        )
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/UseCase/LoadCollectionPreviewsUseCaseTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/UseCase/LoadCollectionPreviewsUseCaseTests.swift
@@ -1,0 +1,76 @@
+//
+//  LoadCollectionPreviewsUseCaseTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import CollectionDomainTesting
+import BaseDomain
+
+@Suite("LoadCollectionPreviewsUseCase")
+struct LoadCollectionPreviewsUseCaseTests {
+
+    @Test("마이페이지 미리보기와 전체 컬렉션 수를 함께 불러온다")
+    func loadSuccess() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionPreviewsResult = .success(([makePreview(), makePreview()], 7))
+        let useCase = DefaultLoadCollectionPreviewsUseCase(collectionRepository: mock)
+
+        let (previews, totalCount) = try await useCase.execute(userID: UserID(1), size: 3)
+
+        #expect(previews.count == 2)
+        #expect(totalCount == 7)
+    }
+
+    @Test("전체 개수는 이번에 받아온 미리보기 개수와 별개다")
+    func totalCountIsIndependentFromPageSize() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionPreviewsResult = .success(([makePreview(), makePreview(), makePreview()], 21))
+        let useCase = DefaultLoadCollectionPreviewsUseCase(collectionRepository: mock)
+
+        let (previews, totalCount) = try await useCase.execute(userID: UserID(1), size: 3)
+
+        #expect(previews.count == 3)
+        #expect(totalCount == 21)
+    }
+
+    @Test("화면이 정한 조회 개수가 그대로 전달된다")
+    func passesRequestedSize() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionPreviewsResult = .success(([], 0))
+        let useCase = DefaultLoadCollectionPreviewsUseCase(collectionRepository: mock)
+
+        _ = try await useCase.execute(userID: UserID(42), size: 3)
+
+        #expect(mock.fetchedPreviewRequests.last?.size == 3)
+        #expect(mock.fetchedPreviewRequests.last?.userID == UserID(42))
+        #expect(mock.fetchedPreviewRequests.count == 1)
+    }
+
+    @Test("조회에 실패하면 에러를 그대로 전달한다")
+    func loadFailure() async {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionPreviewsResult = .failure(.networkUnavailable)
+        let useCase = DefaultLoadCollectionPreviewsUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.networkUnavailable) {
+            try await useCase.execute(userID: UserID(1), size: 3)
+        }
+    }
+}
+
+private extension LoadCollectionPreviewsUseCaseTests {
+    func makePreview() -> CollectionPreview {
+        CollectionPreview(
+            id: CollectionID(1),
+            name: "취향 저격 로판",
+            representativeNovel: CollectionNovel(id: NovelID(1), title: "작품", author: "작가", thumbnailImage: nil)
+        )
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/UseCase/LoadCollectionsUseCaseTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/UseCase/LoadCollectionsUseCaseTests.swift
@@ -1,0 +1,100 @@
+//
+//  LoadCollectionsUseCaseTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import CollectionDomainTesting
+import BaseDomain
+
+@Suite("LoadCollectionsUseCase")
+struct LoadCollectionsUseCaseTests {
+
+    @Test("컬렉션 목록과 전체 개수를 함께 불러온다")
+    func loadSuccess() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionsResult = .success((makePage(cardCount: 2, hasNext: true, nextCursor: "c1"), 12))
+        let useCase = DefaultLoadCollectionsUseCase(collectionRepository: mock)
+
+        let (page, totalCount) = try await useCase.execute(userID: UserID(1), cursor: nil, size: 10)
+
+        #expect(page.items.count == 2)
+        #expect(page.hasNext)
+        #expect(page.nextCursor == "c1")
+        #expect(totalCount == 12)
+    }
+
+    @Test("첫 페이지는 커서 없이 요청한다")
+    func firstPageHasNoCursor() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionsResult = .success((makePage(), 0))
+        let useCase = DefaultLoadCollectionsUseCase(collectionRepository: mock)
+
+        _ = try await useCase.execute(userID: UserID(1), cursor: nil, size: 10)
+
+        #expect(mock.fetchedCollectionRequests.last?.cursor == nil)
+    }
+
+    @Test("다음 페이지는 직전 응답이 준 커서를 그대로 넘긴다")
+    func nextPagePassesCursorAsIs() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionsResult = .success((makePage(), 0))
+        let useCase = DefaultLoadCollectionsUseCase(collectionRepository: mock)
+
+        _ = try await useCase.execute(userID: UserID(1), cursor: "server-issued-cursor", size: 10)
+
+        #expect(mock.fetchedCollectionRequests.last?.cursor == "server-issued-cursor")
+    }
+
+    @Test("마지막 페이지에는 다음 커서가 없다")
+    func lastPageHasNoNextCursor() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionsResult = .success((makePage(hasNext: false, nextCursor: nil), 2))
+        let useCase = DefaultLoadCollectionsUseCase(collectionRepository: mock)
+
+        let (page, _) = try await useCase.execute(userID: UserID(1), cursor: "c1", size: 10)
+
+        #expect(page.hasNext == false)
+        #expect(page.nextCursor == nil)
+    }
+
+    @Test("조회에 실패하면 에러를 그대로 전달한다")
+    func loadFailure() async {
+        let mock = MockCollectionRepository()
+        mock.fetchCollectionsResult = .failure(.forbidden)
+        let useCase = DefaultLoadCollectionsUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.forbidden) {
+            try await useCase.execute(userID: UserID(1), cursor: nil, size: 10)
+        }
+    }
+}
+
+private extension LoadCollectionsUseCaseTests {
+    func makePage(
+        cardCount: Int = 1,
+        hasNext: Bool = false,
+        nextCursor: String? = nil
+    ) -> CursorPaginated<CollectionCard> {
+        CursorPaginated(
+            items: (0..<cardCount).map { index in
+                CollectionCard(
+                    id: CollectionID(index),
+                    name: "컬렉션",
+                    description: nil,
+                    novelCount: 10,
+                    isPrivate: false,
+                    recentNovels: []
+                )
+            },
+            hasNext: hasNext,
+            nextCursor: nextCursor
+        )
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/UseCase/LoadLikedCollectionsUseCaseTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/UseCase/LoadLikedCollectionsUseCaseTests.swift
@@ -1,0 +1,72 @@
+//
+//  LoadLikedCollectionsUseCaseTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import CollectionDomainTesting
+import BaseDomain
+
+@Suite("LoadLikedCollectionsUseCase")
+struct LoadLikedCollectionsUseCaseTests {
+
+    @Test("좋아요한 컬렉션 목록과 전체 개수를 함께 불러온다")
+    func loadSuccess() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchLikedCollectionsResult = .success((makePage(cardCount: 3), 3))
+        let useCase = DefaultLoadLikedCollectionsUseCase(collectionRepository: mock)
+
+        let (page, totalCount) = try await useCase.execute(cursor: nil, size: 10)
+
+        #expect(page.items.count == 3)
+        #expect(totalCount == 3)
+    }
+
+    @Test("좋아요한 목록도 커서를 그대로 넘겨 다음 페이지를 잇는다")
+    func passesCursorAsIs() async throws {
+        let mock = MockCollectionRepository()
+        mock.fetchLikedCollectionsResult = .success((makePage(), 0))
+        let useCase = DefaultLoadLikedCollectionsUseCase(collectionRepository: mock)
+
+        _ = try await useCase.execute(cursor: "server-issued-cursor", size: 20)
+
+        #expect(mock.fetchedLikedRequests.last?.cursor == "server-issued-cursor")
+        #expect(mock.fetchedLikedRequests.last?.size == 20)
+    }
+
+    @Test("조회에 실패하면 에러를 그대로 전달한다")
+    func loadFailure() async {
+        let mock = MockCollectionRepository()
+        mock.fetchLikedCollectionsResult = .failure(.authenticationRequired)
+        let useCase = DefaultLoadLikedCollectionsUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.authenticationRequired) {
+            try await useCase.execute(cursor: nil, size: 10)
+        }
+    }
+}
+
+private extension LoadLikedCollectionsUseCaseTests {
+    func makePage(cardCount: Int = 1) -> CursorPaginated<CollectionCard> {
+        CursorPaginated(
+            items: (0..<cardCount).map { index in
+                CollectionCard(
+                    id: CollectionID(index),
+                    name: "컬렉션",
+                    description: nil,
+                    novelCount: 5,
+                    isPrivate: false,
+                    recentNovels: []
+                )
+            },
+            hasNext: false,
+            nextCursor: nil
+        )
+    }
+}

--- a/Projects/Domain/CollectionDomain/Tests/UseCase/UpdateCollectionUseCaseTests.swift
+++ b/Projects/Domain/CollectionDomain/Tests/UseCase/UpdateCollectionUseCaseTests.swift
@@ -1,0 +1,63 @@
+//
+//  UpdateCollectionUseCaseTests.swift
+//  CollectionDomainTests
+//
+//  Created by YunhakLee on 8/18/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import CollectionDomain
+import CollectionDomainTesting
+import BaseDomain
+
+@Suite("UpdateCollectionUseCase")
+struct UpdateCollectionUseCaseTests {
+
+    @Test("수정하려는 컬렉션 ID와 초안이 함께 전달된다")
+    func updateSuccess() async throws {
+        let mock = MockCollectionRepository()
+        let useCase = DefaultUpdateCollectionUseCase(collectionRepository: mock)
+
+        try await useCase.execute(id: CollectionID(31), draft: makeDraft(name: "바뀐 이름"))
+
+        #expect(mock.updatedRequests.last?.id == CollectionID(31))
+        #expect(mock.updatedRequests.last?.draft.name == "바뀐 이름")
+        #expect(mock.updatedRequests.count == 1)
+    }
+
+    @Test("작품 목록은 부분 수정이 아니라 편집 결과 전체가 전달된다")
+    func sendsWholeNovelList() async throws {
+        let mock = MockCollectionRepository()
+        let useCase = DefaultUpdateCollectionUseCase(collectionRepository: mock)
+
+        try await useCase.execute(
+            id: CollectionID(31),
+            draft: makeDraft(novelIDs: [NovelID(5), NovelID(9)])
+        )
+
+        #expect(mock.updatedRequests.last?.draft.novelIDs == [NovelID(5), NovelID(9)])
+    }
+
+    @Test("수정에 실패하면 에러를 그대로 전달한다")
+    func updateFailure() async {
+        let mock = MockCollectionRepository()
+        mock.updateCollectionResult = .failure(.forbidden)
+        let useCase = DefaultUpdateCollectionUseCase(collectionRepository: mock)
+
+        await #expect(throws: RepositoryError.forbidden) {
+            try await useCase.execute(id: CollectionID(31), draft: makeDraft())
+        }
+    }
+}
+
+private extension UpdateCollectionUseCaseTests {
+    func makeDraft(
+        name: String = "취향 저격 로판",
+        novelIDs: [NovelID] = [NovelID(1)]
+    ) -> CollectionDraft {
+        CollectionDraft(name: name, novelIDs: novelIDs)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 - `WSS-iOS`(V1)는 현재 운영 중인 클라이언트입니다.
 - `WSS-iOS-V2`는 구조 개선과 점진적 기능 이전을 위한 차세대 코드베이스입니다.
 - 현재는 **Core / Domain / Data 레이어 정비와 테스트 가능한 기반 구축**을 우선하고 있습니다.
-- 현재까지 `Core 3개`, `Domain 12개`, `Data 12개` 모듈에 더해 `UI 2개`·`Feature 10개`를 분리했고, Swift Testing과 `/domain-test` 기반 검증 흐름을 갖췄습니다.
+- 현재까지 `Core 3개`, `Domain 13개`, `Data 13개` 모듈에 더해 `UI 2개`·`Feature 11개`를 분리했고, Swift Testing과 `/domain-test` 기반 검증 흐름을 갖췄습니다.
 
 <br/>
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -98,3 +98,6 @@ public final class MockNovelRepository: NovelRepository {
 ## 주의사항 (작업 중 발견 시 누적)
 
 - Mock·테스트가 프로토콜/UseCase 시그니처 변경을 못 따라가 컴파일이 깨지는 drift가 있을 수 있다. 시그니처를 바꾸면 **같은 PR에서 Mock·테스트도 갱신**.
+- ⚠️ **`tuist test`의 `Executed 0 tests, with 0 failures`는 테스트가 안 돌았다는 뜻이 아니다.** 그 줄은 XCTest 카운터라
+  Swift Testing(`@Test`)을 세지 않는다. 실제 실패는 `Failing tests:` + `** TEST FAILED **`로, 성공은 `Test Succeeded`로 나온다.
+  의심되면 일부러 실패하는 테스트를 하나 넣어 러너가 잡는지 확인하면 된다(카나리) — `0 tests`만 보고 러너가 죽었다고 판단하지 말 것.


### PR DESCRIPTION
## 💡 Issue

- closed #191

<br>

## 💭 Summary

컬렉션(Collection) 기능의 Domain·Data 레이어를 신설한다. 컬렉션 목록/상세 조회, 생성·수정·삭제, 좋아요를 아우르는 CRUD 계약과 그 구현, 커서 페이지네이션·에러 변환·DTO↔Entity 매핑까지 레이어를 가로질러 완성했다.

<br>

## 🔑 Key Changes

**Domain — `CollectionDomain` 신설**
- Entity: `CollectionCard` · `CollectionDetail` · `CollectionDraft` · `CollectionNovel` · `CollectionPreview`
- UseCase 8종: `LoadCollections` · `LoadLikedCollections` · `LoadCollectionPreviews` · `LoadCollectionDetail` · `CreateCollection` · `UpdateCollection` · `DeleteCollection` · `CollectionLike`
- `CollectionRepository` 계약 + Domain 테스트(Entity·UseCase) + `MockCollectionRepository`

**Data — `CollectionData` 신설**
- `CollectionEndpoint`, DTO(Query·Request·Response), `CollectionMapper`(DTO↔Entity)
- `CollectionService`/`DefaultCollectionService`, `DefaultCollectionRepository`(에러→`RepositoryError` 변환), `CollectionDataFactory`
- 동작 확인용 `CollectionData` Demo 앱

**공통**
- `CursorPaginated`를 `BaseDomain`으로 승격(레이어 간 재사용)
- `ModuleType.swift`에 두 모듈 등록, `api-spec` 스킬 추가, 관련 `CLAUDE.md`·README·docs 갱신

<br>

## 📱 Simulation

해당 없음 — Domain·Data 레이어 작업으로 Feature(화면) 변경 없음.

<br>

## 🧑‍🧒‍🧒 To Reviewer

- `CursorPaginated`를 `BaseDomain`으로 올린 뒤 컬렉션 목록·좋아요 목록에서 커서 페이지네이션이 일관되게 흐르는지
- `CollectionMapper`의 DTO↔Entity 매핑과 `CollectionEndpoint` 경로/쿼리가 서버 스펙과 맞는지
- `DefaultCollectionRepository`의 에러→`RepositoryError` 변환 분기

<br>

## ※ Reference

- dev 서버 OpenAPI 스펙(`api-spec` 스킬로 조회)
