### PR TITLE
[Feat] #249 - Amplitude·Clarity 애널리틱스 SDK 셋업

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,12 @@
      Firebase SDK 없이는 불가하고 서버가 이미 FCM으로 발송한다(V1도 동일 SDK 사용). #243에서 사용자
      승인 하에 도입, **App 레이어에만 격리**(→ `Projects/App/CLAUDE.md` 푸시 배선). `FirebaseMessaging`
      하나만 링크(Analytics 등 제외). 이 도입이 Tuist 4.29.1→4.206.0 업그레이드를 부른 이유이기도 하다(`.mise.toml`).)
+   - (예외: `AmplitudeSwift`·`Clarity`(SPM) — 애널리틱스(이벤트 트래킹·세션 리플레이)는 서드파티
+     SDK 없이는 불가. #249에서 사용자 승인 하에 도입, **App 레이어에만 격리**(→
+     `Projects/Core/Analytics/CLAUDE.md`의 `AnalyticsTracker` 프로토콜 + `Projects/App/Sources/Analytics/
+     AmplitudeEventTracker.swift`). **Release 스킴에서만 초기화**한다 — Debug 이벤트가 운영 데이터와
+     섞이면 안 돼 `Config_Debug.xcconfig`엔 API 키 자체를 안 둔다(`AppDependencies`/`WSSIOSV2App`이
+     `#if RELEASE`로 가드).)
 6. **작업 방식**: 브랜치 `Type/#이슈` (예: `Docs/#130`), 커밋 `[Type] #이슈 - 한글 설명`, 머지는 PR 경유(브랜치 보호). → [docs/WORKFLOW.md](docs/WORKFLOW.md)
 
 ---

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/ModuleType.swift
@@ -75,11 +75,12 @@ public enum DataModule: String, ModuleSpec {
 
 public enum CoreModule: String, ModuleSpec {
     public var moduleSuffix: String { "" }
-    
+
     case keychain
     case networking
     case logger
     case pushAuthorization
+    case analytics
 }
 
 public enum UIModule: String, ModuleSpec {

--- a/Projects/App/CLAUDE.md
+++ b/Projects/App/CLAUDE.md
@@ -224,6 +224,23 @@ Domain/Data는 `DevicePushToken`/`RegisterDeviceTokenUseCase`(NotificationDomain
   프로파일이 아니라 `match Development` 프로파일을 선택해야 설치되고 `tuist generate`가 그 선택을 App Store로 리셋한다 —
   이 서명 함정은 `docs/FASTLANE_ONBOARDING.md` 참고.
 
+## 애널리틱스(Amplitude·Clarity) 배선 (#249)
+
+Amplitude(이벤트 트래킹)·Microsoft Clarity(세션 리플레이·히트맵) **둘 다 App 레이어에만 격리**한다 —
+Core/Analytics는 `AnalyticsTracker` 프로토콜만 알고 이 SDK들을 모른다(`Logger`와 동일한 격리 패턴).
+
+- **`AmplitudeEventTracker`**(`Sources/Analytics/AmplitudeEventTracker.swift`)가 `AnalyticsTracker` 구현체 —
+  `AppDependencies.analyticsTracker`로 조립돼 각 Feature Factory에 `logger: Logger? = nil`과 동일한 형태로
+  주입될 예정(옵셔널·nil 기본값, Demo/테스트는 nil).
+- **Clarity는 프로토콜 대상이 아니다** — 커스텀 이벤트 API가 아니라 세션 자동 수집이라 `WSSIOSV2App.init()`에서
+  Kakao SDK와 같은 자리에 1회 초기화만 한다(Feature가 호출할 게 없음).
+- ⚠️ **둘 다 Release 스킴에서만 초기화한다**(사용자 확정) — Debug 이벤트가 운영 데이터와 섞이면 안 된다.
+  `Config_Debug.xcconfig`엔 `AMPLITUDE_API_KEY`/`CLARITY_PROJECT_ID` 키 자체가 없어 `NetworkingConfig`가
+  빈 문자열을 읽고, `AppDependencies`/`WSSIOSV2App` 양쪽이 `#if RELEASE` + 빈 문자열 체크로 이중 가드한다 —
+  Debug 빌드에선 `analyticsTracker`가 `nil`이라 모든 호출부(`analyticsTracker?.track(...)`)가 자동 no-op.
+- **Amplitude는 이벤트를 콘솔에 미리 등록할 필요가 없다** — SDK가 보내는 이벤트명을 첫 발생 시점에 자동
+  수집하는 구조라, 이벤트명·프로퍼티만 코드에서 정하면 된다(Amplitude 자체 특성, 콘솔 작업 불필요).
+
 ## 주의사항 (작업 중 발견 시 누적)
 
 - **재발급(/reissue) 전용 URLSession엔 요청 타임아웃 10초가 걸려 있다**(#236, `AppDependencies`의

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -106,6 +106,11 @@ let targets: [Target] = [
             // FCM 푸시 알림 수신·토큰 발급(#243). Firebase는 App 레이어에만 격리한다 — Domain/Data는
             // DevicePushToken/RegisterDeviceTokenUseCase 추상화로 이미 분리돼 있어 Firebase를 모른다.
             .external(name: "FirebaseMessaging"),
+            // Amplitude·Microsoft Clarity 애널리틱스(#249). App 레이어에만 격리 — Core/Analytics는
+            // AnalyticsTracker 프로토콜만 노출하고 이 SDK들을 모른다(`Sources/Analytics/AmplitudeEventTracker.swift`).
+            .external(name: "AmplitudeSwift"),
+            .external(name: "Clarity"),
+            .module(.core(.analytics)),
             // 온보딩 플로우 조립(App이 유일한 DI 지점) — Feature + Domain(UseCase 타입) + Data(Factory 구현체) + Core.
             .module(.feature(.onboarding)),
             .module(.domain(.base)),

--- a/Projects/App/Sources/Analytics/AmplitudeEventTracker.swift
+++ b/Projects/App/Sources/Analytics/AmplitudeEventTracker.swift
@@ -1,0 +1,41 @@
+//
+//  AmplitudeEventTracker.swift
+//  WSS-iOS
+//
+//  Created by Claude on 9/7/26.
+//  Copyright © 2026 kr.websoso.app. All rights reserved.
+//
+
+import Foundation
+
+import AmplitudeSwift
+
+import Analytics
+
+/// `AnalyticsTracker`의 Amplitude 구현체(#249). App 레이어에만 존재 — Core/Analytics는 Amplitude를 모른다.
+/// `@unchecked Sendable`: 유일한 저장 상태가 `Amplitude`(SDK 자체가 내부 이벤트 큐로 스레드 세이프,
+/// 30초/30건 배치로 자체 flush)라 `WSSImageCache`(NSCache 래퍼)와 같은 결.
+final class AmplitudeEventTracker: AnalyticsTracker, @unchecked Sendable {
+    private let amplitude: Amplitude
+
+    init(apiKey: String) {
+        amplitude = Amplitude(configuration: Configuration(apiKey: apiKey))
+    }
+
+    func track(_ name: String, properties: [String: AnalyticsPropertyValue]?) {
+        amplitude.track(eventType: name, eventProperties: properties?.mapValues(\.rawValue))
+    }
+}
+
+private extension AnalyticsPropertyValue {
+    /// Amplitude SDK가 받는 `[String: Any]?`로 풀어주는 변환 — `AnalyticsTracker`가 `Any` 대신 고정
+    /// 케이스만 노출하는 이유(Sendable)는 `Core/Analytics/CLAUDE.md` 참고.
+    var rawValue: Any {
+        switch self {
+        case let .string(value): value
+        case let .int(value): value
+        case let .double(value): value
+        case let .bool(value): value
+        }
+    }
+}

--- a/Projects/App/Sources/DI/AppDependencies.swift
+++ b/Projects/App/Sources/DI/AppDependencies.swift
@@ -36,9 +36,9 @@ import SearchData
 import SettingData
 import SocialData
 import SplashData
+import Analytics
 import Logger
 import Networking
-import Analytics
 
 /// App(DI)의 유일한 조립 지점 — Data 구현체와 Domain 프로토콜이 만나는 곳.
 /// 온보딩 플로우 + 로그인 이후 진입하는 메인 탭(홈/피드/서재/My)이 필요로 하는 Repository까지 조립한다.

--- a/Projects/App/Sources/DI/AppDependencies.swift
+++ b/Projects/App/Sources/DI/AppDependencies.swift
@@ -38,6 +38,7 @@ import SocialData
 import SplashData
 import Logger
 import Networking
+import Analytics
 
 /// App(DI)의 유일한 조립 지점 — Data 구현체와 Domain 프로토콜이 만나는 곳.
 /// 온보딩 플로우 + 로그인 이후 진입하는 메인 탭(홈/피드/서재/My)이 필요로 하는 Repository까지 조립한다.
@@ -79,10 +80,23 @@ final class AppDependencies {
     /// 피드 작성 완료 → 피드 탭 목록 재로드 신호(앱 전역). Repository가 아니라 App 조정 계층 소유의
     /// 화면 간 상태라 여기 두되, 4탭 Root가 공유해야 해서 `AppDependencies`에 실어 나른다.
     let feedListInvalidation = FeedListInvalidation()
+    /// 이벤트 트래킹(#249) — Release 스킴에서만 실제 Amplitude 인스턴스, Debug는 nil(모든 호출부가
+    /// `analyticsTracker?.track(...)`라 자동 no-op). `Logger`와 동일한 옵셔널 주입 패턴.
+    let analyticsTracker: AnalyticsTracker?
 
     init() {
         let logger = ConsoleLogger()
         self.logger = logger
+
+        // Release 스킴에서만, 그리고 키가 실제로 있을 때만 만든다(#249) — Debug는
+        // Config_Debug.xcconfig에 AMPLITUDE_API_KEY 키 자체가 없어 빈 문자열로 읽히므로 이중 가드.
+        #if RELEASE
+        self.analyticsTracker = NetworkingConfig.amplitudeAPIKey.isEmpty
+            ? nil
+            : AmplitudeEventTracker(apiKey: NetworkingConfig.amplitudeAPIKey)
+        #else
+        self.analyticsTracker = nil
+        #endif
 
         let tokenStore = DefaultTokenStore()
 

--- a/Projects/App/Sources/WSSIOSV2App.swift
+++ b/Projects/App/Sources/WSSIOSV2App.swift
@@ -3,6 +3,9 @@ import SwiftUI
 import KakaoSDKAuth
 import KakaoSDKCommon
 
+import Clarity
+
+import BaseData
 import BaseDomain
 import DesignSystem
 
@@ -34,6 +37,15 @@ struct WSSIOSV2App: App {
             return
         }
         KakaoSDK.initSDK(appKey: kakaoAppKey)
+
+        // Microsoft Clarity(#249) — 세션 리플레이·히트맵 자동 수집. Amplitude(AppDependencies에서 조립)와
+        // 마찬가지로 Release 스킴에서만 초기화한다(Debug 이벤트가 운영 데이터와 섞이면 안 됨,
+        // Config_Debug.xcconfig엔 CLARITY_PROJECT_ID 키 자체가 없어 빈 문자열로 읽힌다).
+        #if RELEASE
+        if !NetworkingConfig.clarityProjectID.isEmpty {
+            ClaritySDK.initialize(config: ClarityConfig(projectId: NetworkingConfig.clarityProjectID))
+        }
+        #endif
     }
 
     var body: some Scene {

--- a/Projects/App/Sources/WSSIOSV2App.swift
+++ b/Projects/App/Sources/WSSIOSV2App.swift
@@ -1,9 +1,8 @@
 import SwiftUI
 
+import Clarity
 import KakaoSDKAuth
 import KakaoSDKCommon
-
-import Clarity
 
 import BaseData
 import BaseDomain

--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -47,6 +47,8 @@
 	<string>$(KAKAO_COLLECTION_SHARE_TEMPLATE_ID_3)</string>
 	<key>AMPLITUDE_API_KEY</key>
 	<string>$(AMPLITUDE_API_KEY)</string>
+	<key>CLARITY_PROJECT_ID</key>
+	<string>$(CLARITY_PROJECT_ID)</string>
 	<key>APPSTORE_ID</key>
 	<string>$(APPSTORE_ID)</string>
 	<key>TEST_API_KEY</key>

--- a/Projects/Core/Analytics/CLAUDE.md
+++ b/Projects/Core/Analytics/CLAUDE.md
@@ -1,0 +1,32 @@
+<!-- 모듈 가이드. 이 모듈 작업 시 상위 Projects/Core/CLAUDE.md(레이어 규칙)와 함께 자동 로드됨. -->
+# Analytics
+
+이벤트 트래킹 추상화(`AnalyticsTracker` 프로토콜). `Logger`와 동일한 형태 — 이 모듈은 Amplitude·Microsoft
+Clarity 등 구체 SDK를 **모른다**(#249). 구현체는 App 레이어에만 격리되고(외부 의존성 예외, 루트
+`CLAUDE.md` 5번), 이 모듈은 순수 프로토콜만 노출해 Feature가 App을 몰라도 자유롭게 이벤트를 보낼 수 있게 한다.
+
+- 식별자: `ModuleType.core(.analytics)` / 의존: 없음(순수 프로토콜)
+- 진입점: 없음(Factory 없음) — Feature는 `AnalyticsTracker?`를 `logger: Logger? = nil`과 동일한 형태(옵셔널·
+  nil 기본값)로 Factory→ViewModel 주입받는다. 실제 인스턴스는 App(DI)이, Demo/테스트는 nil.
+
+## 핵심 시나리오
+
+- `track(_ name: String, properties: [String: AnalyticsPropertyValue]?)` 하나뿐 — Amplitude 이벤트 스키마는
+  콘솔에 미리 등록할 필요 없이 SDK가 보내는 이벤트명을 그대로 수집하는 구조라, 이 프로토콜도 이벤트명 문자열
+  하나만 받는 얇은 형태로 충분하다.
+- **`properties`는 `Any`가 아니라 `AnalyticsPropertyValue`(string/int/double/bool) 고정 케이스** — 프로토콜이
+  `Sendable`이어야 하는데(Swift 6 mode 6 대비, `Logger`와 동일 이유) `Any`는 Sendable을 보장 못 한다.
+- Clarity는 커스텀 이벤트 API가 아니라 세션 자동 수집(리플레이·히트맵) 위주라 이 프로토콜 대상이 아니다 —
+  App 초기화 시점에 SDK만 띄우면 되고 Feature가 호출할 게 없다.
+- **이벤트 이름은 문자열 리터럴로 호출부에 흩뿌리지 않는다** — 각 Feature 모듈이 자기 화면 이벤트만 담은
+  `enum XxxAnalyticsEvent: String, AnalyticsEvent`(마커 프로토콜, 이 모듈이 제공)를 선언하고,
+  `AnalyticsTracker.track<Event: AnalyticsEvent>(_:properties:)` 제네릭 오버로드가 `rawValue`로 풀어
+  문자열 버전에 위임한다. 이벤트 enum 자체는 **Core가 아니라 그 이벤트를 쓰는 Feature 모듈에** 둔다 —
+  Core는 제품 개념(화면·액션)을 모른다는 원칙 유지, 이 모듈은 마커 프로토콜(`RawValue == String` 제약)만
+  제공한다. Feature ViewModel의 `track(_:properties:)` pass-through도 그 모듈의 `Event` 타입 하나로
+  제네릭하게 두면 된다(`Logger`의 `logger?.error(...)`와 달리, Analytics는 이벤트 종류가 많아 enum
+  하나로 카탈로그화하는 이유).
+
+## 주의사항 (작업 중 발견 시 누적)
+
+- (없음 — 발견 시 추가)

--- a/Projects/Core/Analytics/Project.swift
+++ b/Projects/Core/Analytics/Project.swift
@@ -1,0 +1,15 @@
+//
+//  Project.swift
+//  AppManifests
+//
+//  Created by Claude on 9/7/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.createCoreModule(
+    name: ModuleType.core(.analytics).name,
+    targets: [.sources]
+)

--- a/Projects/Core/Analytics/Sources/AnalyticsTracker.swift
+++ b/Projects/Core/Analytics/Sources/AnalyticsTracker.swift
@@ -1,0 +1,41 @@
+//
+//  AnalyticsTracker.swift
+//  Analytics
+//
+//  Created by Claude on 9/7/26.
+//
+
+import Foundation
+
+/// 이벤트 트래킹 추상화. `Logger`와 동일한 형태 — 이 모듈은 Amplitude/Clarity 등 구체 SDK를 모른다.
+/// Feature는 이 프로토콜만 보고 호출하고, 실제 구현체는 App(DI)이 만들어 Factory 체인으로 주입한다.
+public protocol AnalyticsTracker: Sendable {
+    func track(_ name: String, properties: [String: AnalyticsPropertyValue]?)
+}
+
+public extension AnalyticsTracker {
+    func track(_ name: String) {
+        track(name, properties: nil)
+    }
+
+    /// `AnalyticsEvent` enum으로 호출하는 타입 세이프 오버로드 — 이벤트 이름 문자열을 호출부에 흩뿌리지
+    /// 않는다. 각 Feature 모듈이 자기 화면의 이벤트만 담은 `enum XxxAnalyticsEvent: String, AnalyticsEvent`를
+    /// 선언하면(레이어 규칙상 이 모듈에 두지 않는다 — Core는 제품 개념을 모른다), 이 확장이 `rawValue`로
+    /// 풀어 위 문자열 버전으로 위임한다.
+    func track<Event: AnalyticsEvent>(_ event: Event, properties: [String: AnalyticsPropertyValue]? = nil) {
+        track(event.rawValue, properties: properties)
+    }
+}
+
+/// 이벤트 이름 enum이 채택하는 마커 프로토콜. `RawValue == String`만 요구해 각 Feature 모듈이 제품
+/// 개념(화면·액션)을 아는 자기 이벤트 enum을 독립적으로 선언할 수 있게 한다 — 이 프로토콜 자체는
+/// 어떤 이벤트가 있는지 모른다(Core는 위를 모른다는 원칙 유지).
+public protocol AnalyticsEvent: RawRepresentable, Sendable where RawValue == String {}
+
+/// 이벤트 프로퍼티 값. `Any` 대신 고정된 케이스만 허용해 `Sendable`을 지킨다(Swift 6 mode 6 대비).
+public enum AnalyticsPropertyValue: Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+}

--- a/Projects/Core/CLAUDE.md
+++ b/Projects/Core/CLAUDE.md
@@ -13,6 +13,7 @@
 | `Keychain` | 보안 저장소, 키체인 접근 래퍼 |
 | `Logger` | 로깅 추상화, 콘솔 로거 |
 | `PushAuthorization` | 시스템 푸시 알림 권한 확인·요청 래퍼(`UserNotifications`) |
+| `Analytics` | 이벤트 트래킹 추상화(`AnalyticsTracker`) — Amplitude/Clarity 등 구체 SDK는 모름(#249) |
 
 ## 의존 규칙
 

--- a/Projects/Data/BaseData/CLAUDE.md
+++ b/Projects/Data/BaseData/CLAUDE.md
@@ -21,6 +21,11 @@ Data 레이어의 **공통 인프라**. 거의 모든 Data 모듈이 의존한�
 
 - **`ImageURLResolver.displayScale`은 UI 컨텍스트(루트 뷰 `@Environment(\.displayScale)`)에서 1회 주입**해야 한다 — 매퍼(백그라운드)에서 `UITraitCollection.current`를 읽으면 0이 나올 수 있어 값 주입 방식을 택했다. 미주입 시 기본 3(@3x — 전 기기에서 다운스케일이라 안전).
 - **plist 키(`BASE_URL` 등)는 Tuist `ModuleInfoPlist`가 featureDemo/data 타깃에만 주입**한다 — 새 키를 추가하면 xcconfig뿐 아니라 `Tuist/ProjectDescriptionHelpers/ModuleInfoPlist.swift`에도 넣어야 Bundle에서 읽힌다(빼먹으면 조용히 빈 문자열).
+- ⚠️ **`NetworkingConfig.amplitudeAPIKey`/`clarityProjectID`(#249)가 Debug 빌드에서 빈 문자열인 건 버그가
+  아니라 의도다** — 애널리틱스는 Release 스킴에서만 동작하도록 사용자가 확정해, `Config_Debug.xcconfig`엔
+  이 두 키 자체를 안 둔다(`Config_Release.xcconfig`에만 존재). App(`AppDependencies`/`WSSIOSV2App`)이
+  `#if RELEASE` + 빈 문자열 체크로 이중 가드하니, Debug에서 값이 비어 보여도 `Config_Debug.xcconfig`에
+  키를 추가해 "고치려" 하지 말 것.
 - `KeywordCache`는 **파일 기반**(캐시 디렉토리의 `keywords.json` JSON). "로컬 DB"라 부르지만 실제론 파일 캐시. 실패는 `CacheError`.
 - 키워드는 `syncKeywords()`로 서버→파일 동기화 후, 다른 도메인이 캐시에서 읽어 주입받는 구조.
 - `StorageKey` 추가 시 타입(`V`)을 정확히 — `UserDefaultsStorage`는 `as? V` 캐스팅이라 타입 불일치는 조용히 nil.

--- a/Projects/Data/BaseData/Sources/Networking/NetworkingConfig.swift
+++ b/Projects/Data/BaseData/Sources/Networking/NetworkingConfig.swift
@@ -20,6 +20,7 @@ enum Config {
             static let kakaoCollectionShareTemplateID3 = "KAKAO_COLLECTION_SHARE_TEMPLATE_ID_3"
             static let appStoreID = "APPSTORE_ID"
             static let amplitudeAPIKey = "AMPLITUDE_API_KEY"
+            static let clarityProjectID = "CLARITY_PROJECT_ID"
         }
     }
 }
@@ -45,4 +46,9 @@ public enum NetworkingConfig {
     public static let kakaoCollectionShareTemplateID3: Int64 = Int64(
         Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.kakaoCollectionShareTemplateID3) as? String ?? ""
     ) ?? 0
+    // Amplitude·Clarity(#249)는 Release 스킴에만 값이 있다(Config_Debug.xcconfig엔 키 자체가 없음) —
+    // Debug 빌드에선 둘 다 빈 문자열이 되고, App(`AppDependencies`/`WSSIOSV2App`)이 `#if RELEASE`로
+    // 가드해 초기화 자체를 건너뛴다(빈 키로 SDK를 초기화하지 않는다).
+    public static let amplitudeAPIKey: String = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.amplitudeAPIKey) as? String ?? ""
+    public static let clarityProjectID: String = Bundle.main.object(forInfoDictionaryKey: Config.Keys.Plist.clarityProjectID) as? String ?? ""
 }

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "6e64f62a1f915e2fd483dd397775392fd64790e99d0a07c69572b404833533a8",
+  "originHash" : "6801e1663c0c4fa6ee2addb8b6b518cdcf03affa677cc05c591f3e4ef4ea0268",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "location" : "https://github.com/google/abseil-cpp-binary",
       "state" : {
         "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
         "version" : "1.2024011602.0"
@@ -13,25 +13,61 @@
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "location" : "https://github.com/Alamofire/Alamofire",
       "state" : {
         "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
         "version" : "5.12.0"
       }
     },
     {
+      "identity" : "amplitude-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-Swift",
+      "state" : {
+        "revision" : "9479e13442caea26cef9e0a84ce9b97cd74bff83",
+        "version" : "1.18.8"
+      }
+    },
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift",
+      "state" : {
+        "revision" : "ff75492c13d93031d7b387d2f380fe4e2ae69e61",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios",
+      "state" : {
+        "revision" : "6d1a5b9666192861342b70ea0b2274180a5e1d4f",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "app-check",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/app-check.git",
+      "location" : "https://github.com/google/app-check",
       "state" : {
         "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
         "version" : "11.2.0"
       }
     },
     {
+      "identity" : "clarity-apps",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/clarity-apps",
+      "state" : {
+        "revision" : "3629b67b2a023b45ee79a0769491ff3e45804da2",
+        "version" : "4.0.0"
+      }
+    },
+    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
         "revision" : "0d885d28250fb1196b614bc9455079b75c531f72",
         "version" : "11.7.0"
@@ -40,7 +76,7 @@
     {
       "identity" : "googleappmeasurement",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "location" : "https://github.com/google/GoogleAppMeasurement",
       "state" : {
         "revision" : "be0881ff728eca210ccb628092af400c086abda3",
         "version" : "11.7.0"
@@ -49,7 +85,7 @@
     {
       "identity" : "googledatatransport",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "location" : "https://github.com/google/GoogleDataTransport",
       "state" : {
         "revision" : "ba3358d3c3dbae8ef230b58a46b97ad65e84e974",
         "version" : "10.1.1"
@@ -58,7 +94,7 @@
     {
       "identity" : "googleutilities",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleUtilities.git",
+      "location" : "https://github.com/google/GoogleUtilities",
       "state" : {
         "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
         "version" : "8.1.3"
@@ -67,7 +103,7 @@
     {
       "identity" : "grpc-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/grpc-binary.git",
+      "location" : "https://github.com/google/grpc-binary",
       "state" : {
         "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
         "version" : "1.65.1"
@@ -76,7 +112,7 @@
     {
       "identity" : "gtm-session-fetcher",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "location" : "https://github.com/google/gtm-session-fetcher",
       "state" : {
         "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
         "version" : "4.5.0"
@@ -85,7 +121,7 @@
     {
       "identity" : "interop-ios-for-google-sdks",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks",
       "state" : {
         "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
         "version" : "100.0.0"
@@ -94,7 +130,7 @@
     {
       "identity" : "kakao-ios-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kakao/kakao-ios-sdk.git",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
       "state" : {
         "revision" : "2a68ca01e2d7900a1559b31d0d59843837f130f2",
         "version" : "2.28.0"
@@ -103,7 +139,7 @@
     {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/leveldb.git",
+      "location" : "https://github.com/firebase/leveldb",
       "state" : {
         "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
         "version" : "1.22.5"
@@ -112,7 +148,7 @@
     {
       "identity" : "lottie-spm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-spm.git",
+      "location" : "https://github.com/airbnb/lottie-spm",
       "state" : {
         "revision" : "8c6edf4f0fa84fe9c058600a4295eb0c01661c69",
         "version" : "4.5.1"
@@ -121,7 +157,7 @@
     {
       "identity" : "nanopb",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/nanopb.git",
+      "location" : "https://github.com/firebase/nanopb",
       "state" : {
         "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
         "version" : "2.30910.1"
@@ -130,7 +166,7 @@
     {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/promises.git",
+      "location" : "https://github.com/google/promises",
       "state" : {
         "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
         "version" : "2.4.1"
@@ -139,7 +175,7 @@
     {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
+      "location" : "https://github.com/apple/swift-protobuf",
       "state" : {
         "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
         "version" : "1.38.1"

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -37,6 +37,11 @@ let package = Package(
         .package(url: "https://github.com/kakao/kakao-ios-sdk.git", exact: "2.28.0"),
         // FCM 푸시 알림(#243). FirebaseMessaging 프로덕트만 App 타깃에서 .external로 링크한다
         // (Analytics 등은 제외 — 최소 의존). 버전은 V1(운영)과 동일하게 고정.
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "11.7.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "11.7.0"),
+        // Amplitude·Microsoft Clarity 애널리틱스(#249) — App 레이어에만 격리해서 링크한다
+        // (Core/Analytics는 AnalyticsTracker 프로토콜만 노출, 이 SDK들을 모른다). Release 스킴에서만
+        // 실제로 초기화한다(Debug는 이벤트를 안 쏨, `AppDependencies` 참고).
+        .package(url: "https://github.com/amplitude/Amplitude-Swift.git", exact: "1.18.8"),
+        .package(url: "https://github.com/microsoft/clarity-apps.git", exact: "4.0.0")
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/ModuleInfoPlist.swift
+++ b/Tuist/ProjectDescriptionHelpers/ModuleInfoPlist.swift
@@ -57,6 +57,7 @@ public enum ModuleInfoPlist {
         case .data:
             var entries = commonEntries
             entries["AMPLITUDE_API_KEY"] = "$(AMPLITUDE_API_KEY)"
+            entries["CLARITY_PROJECT_ID"] = "$(CLARITY_PROJECT_ID)"
             entries["BASE_URL"] = "$(BASE_URL)"
             entries["TEST_API_KEY"] = "$(TEST_API_KEY)"
             entries["BUCKET_URL"] = "$(BUCKET_URL)"


### PR DESCRIPTION
## 💡 Issue
- closed #249

<br>

## 💭 Summary
앱 애널리틱스(Amplitude·Microsoft Clarity) 도입을 위한 인프라 셋업이에요.

두 SDK를 App 레이어에만 격리하고, Core에는 `AnalyticsTracker` 프로토콜만 둬서 Feature 레이어가 SDK를 몰라도 이벤트를 보낼 수 있게 했어요.

실제로 각 Feature 화면에 이벤트를 배선하는 작업은 범위가 커서 후속 이슈(#250)로 분리했어요.

<br>

## 🔑 Key Changes

**Core/Analytics 모듈 신설**
- `AnalyticsTracker` 프로토콜 — `Logger`와 동일한 "protocol만 Core, 구현은 App" 패턴이에요.
- `AnalyticsEvent`(RawRepresentable 마커 프로토콜) + `AnalyticsPropertyValue`(`Any` 대신 쓰는 Sendable-safe 값 타입)로, Feature 모듈이 하드코딩 문자열 대신 enum 이벤트 카탈로그를 타입 세이프하게 관리할 수 있게 했어요.

**App 레이어 SDK 셋업**
- `Tuist/Package.swift`에 `Amplitude-Swift`(1.18.8), `clarity-apps`(4.0.0) SPM 의존성을 추가했어요.
- `AmplitudeEventTracker`(`AnalyticsTracker` 구현체)를 만들고 `AppDependencies`에서 조립해요.
- Clarity는 커스텀 이벤트 API가 없어서 `WSSIOSV2App.init()`에서 세션 자동 수집만 1회 초기화해요.
- `NetworkingConfig`에 `amplitudeAPIKey`/`clarityProjectID` 키를 추가했어요.

**Debug 빌드는 절대 이벤트를 안 보내요**
- `AppDependencies`(Amplitude)·`WSSIOSV2App`(Clarity) 양쪽 다 `#if RELEASE` + 빈 문자열 체크로 이중 가드했어요.
- `Config_Debug.xcconfig`엔 API 키 자체를 안 둬서, Debug 빌드에서는 `analyticsTracker`가 항상 `nil`이라 모든 호출부가 자동으로 no-op이 돼요.

<br>

## 📱 Simulation
해당 없음 — UI 변경 없는 SDK 셋업/DI 작업이에요.

<br>

## 🧑‍🧒‍🧒 To Reviewer
- 서드파티 라이브러리(Amplitude, Clarity) 신규 도입은 루트 `CLAUDE.md`의 "외부 의존성 없음 원칙" 예외 목록에 이미 명시돼 있어요(사용자 승인 하에 진행).
- 이 PR엔 아직 어떤 Feature 화면에서도 실제로 이벤트를 발화하는 코드가 없어요 — `analyticsTracker`는 조립만 되고 아직 아무도 안 씁니다. 화면별 배선은 #250에서 이어져요.
- Release 스킴으로 빌드하면 `analyticsTracker`가 non-nil이 되고, Debug 스킴에서는 `nil`인지 확인해보시면 좋을 것 같아요.

<br>

## ※ Reference
해당 없음
